### PR TITLE
Ant changes to enable Calabash to be deployed to Maven Central

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -510,13 +510,18 @@ java -Xmx1024m -jar %INSTALL_PATH/calabash.jar "$@"
   </target>
 
   <target name="maven-stage" depends="maven-dist" description="deploy release version to Maven staging repository">
-    <!-- sign and deploy the main artifact -->
+    <input message="Please enter your GPG passphrase:" addproperty="passphrase">
+        <handler type="secure"/>
+    </input>
+
+      <!-- sign and deploy the main artifact -->
     <artifact:mvn>
       <arg value="org.apache.maven.plugins:maven-gpg-plugin:1.3:sign-and-deploy-file" />
       <arg value="-Durl=${maven-staging-repository-url}" />
       <arg value="-DrepositoryId=${maven-staging-repository-id}" />
       <arg value="-DpomFile=${maven.dir}/pom.xml" />
       <arg value="-Dfile=${maven-jar}" />
+      <arg value="-Dgpg.passphrase=${passphrase}" />
       <arg value="-Pgpg" />
     </artifact:mvn>
 
@@ -528,6 +533,7 @@ java -Xmx1024m -jar %INSTALL_PATH/calabash.jar "$@"
       <arg value="-DpomFile=${maven.dir}/pom.xml" />
       <arg value="-Dfile=${maven-sources-jar}" />
       <arg value="-Dclassifier=sources" />
+      <arg value="-Dgpg.passphrase=${passphrase}" />
       <arg value="-Pgpg" />
     </artifact:mvn>
 
@@ -539,6 +545,7 @@ java -Xmx1024m -jar %INSTALL_PATH/calabash.jar "$@"
       <arg value="-DpomFile=${maven.dir}/pom.xml" />
       <arg value="-Dfile=${maven-javadoc-jar}" />
       <arg value="-Dclassifier=javadoc" />
+      <arg value="-Dgpg.passphrase=${passphrase}" />
       <arg value="-Pgpg" />
     </artifact:mvn>
   </target>

--- a/build.xml
+++ b/build.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project name="calabash" default="default" basedir=".">
+<project name="calabash" default="default" basedir="." xmlns:artifact="antlib:org.apache.maven.artifact.ant">
   <description>Builds the distribution jar because IntelliJ sucks at it</description>
 
   <property file="resources/etc/vendor.properties"/>
@@ -28,6 +28,22 @@
   <available property="izpack.present"
              classname="com.izforge.izpack.ant.IzPackTask"
              classpath="${izpack.dir}/lib/compiler.jar"/>
+
+  <!-- define Maven coordinates -->
+  <property name="groupId" value="com.xmlcalabash" />
+  <property name="artifactId" value="xmlcalabash" />
+
+  <!-- define artifact names, which follow the convention of Maven -->
+  <property name="maven.dir" value="${dist.dir}/maven" />
+  <property name="maven-jar" value="${maven.dir}/${artifactId}-${version}.jar" />
+  <property name="maven-javadoc-jar" value="${maven.dir}/${artifactId}-${version}-javadoc.jar" />
+  <property name="maven-sources-jar" value="${maven.dir}/${artifactId}-${version}-sources.jar" />
+
+  <!-- define maven snapshots and staging repository id and url -->
+  <property name="maven-snapshots-repository-id" value="sonatype-nexus-snapshots" />
+  <property name="maven-snapshots-repository-url" value="https://oss.sonatype.org/content/repositories/snapshots/" />
+  <property name="maven-staging-repository-id" value="sonatype-nexus-staging" />
+  <property name="maven-staging-repository-url" value="https://oss.sonatype.org/service/local/staging/deploy/maven2/" />
 
   <target name="izpacktool" if="izpack.present">
     <taskdef name="izpack"
@@ -458,5 +474,74 @@ java -Xmx1024m -jar %INSTALL_PATH/calabash.jar "$@"
       <arg value="password=${submit.password}"/>
     </java>
   </target>
+
+  <target name="maven-dist" depends="init,compile-everything" description="generate Maven jars">
+    <!-- build the main artifact -->
+      <jar destfile="${maven-jar}">
+          <manifest>
+              <attribute name="Built-By" value="${built.by}"/>
+              <attribute name="Implementation-Vendor" value="${implementation.vendor}"/>
+              <attribute name="Implementation-Title" value="${implementation.title}"/>
+              <attribute name="Implementation-Version" value="${dist-version}"/>
+              <attribute name="Main-Class" value="com.xmlcalabash.drivers.Main"/>
+              <attribute name="Class-Path" value="${run.classpath}"/>
+          </manifest>
+
+          <fileset dir="${build.dir}"/>
+      </jar>
+
+    <!-- build the javadoc artifact -->
+    <javadoc sourcepath="src" destdir="${build.dir}/javadoc" />
+    <jar jarfile="${maven-javadoc-jar}">
+      <fileset dir="${build.dir}/javadoc" />
+    </jar>
+
+    <!-- build the sources artifact -->
+    <jar jarfile="${maven-sources-jar}">
+      <fileset dir="src" />
+    </jar>
+
+    <!-- Update the version in the POM -->
+    <copy file="pom.xml" toFile="${maven.dir}/pom.xml">
+      <filterset>
+         <filter token="version" value="${version}"/>
+      </filterset>
+    </copy>
+  </target>
+
+  <target name="maven-stage" depends="maven-dist" description="deploy release version to Maven staging repository">
+    <!-- sign and deploy the main artifact -->
+    <artifact:mvn>
+      <arg value="org.apache.maven.plugins:maven-gpg-plugin:1.3:sign-and-deploy-file" />
+      <arg value="-Durl=${maven-staging-repository-url}" />
+      <arg value="-DrepositoryId=${maven-staging-repository-id}" />
+      <arg value="-DpomFile=${maven.dir}/pom.xml" />
+      <arg value="-Dfile=${maven-jar}" />
+      <arg value="-Pgpg" />
+    </artifact:mvn>
+
+    <!-- sign and deploy the sources artifact -->
+    <artifact:mvn>
+      <arg value="org.apache.maven.plugins:maven-gpg-plugin:1.3:sign-and-deploy-file" />
+      <arg value="-Durl=${maven-staging-repository-url}" />
+      <arg value="-DrepositoryId=${maven-staging-repository-id}" />
+      <arg value="-DpomFile=${maven.dir}/pom.xml" />
+      <arg value="-Dfile=${maven-sources-jar}" />
+      <arg value="-Dclassifier=sources" />
+      <arg value="-Pgpg" />
+    </artifact:mvn>
+
+    <!-- sign and deploy the javadoc artifact -->
+    <artifact:mvn>
+      <arg value="org.apache.maven.plugins:maven-gpg-plugin:1.3:sign-and-deploy-file" />
+      <arg value="-Durl=${maven-staging-repository-url}" />
+      <arg value="-DrepositoryId=${maven-staging-repository-id}" />
+      <arg value="-DpomFile=${maven.dir}/pom.xml" />
+      <arg value="-Dfile=${maven-javadoc-jar}" />
+      <arg value="-Dclassifier=javadoc" />
+      <arg value="-Pgpg" />
+    </artifact:mvn>
+  </target>
+
 
 </project>

--- a/build.xml
+++ b/build.xml
@@ -477,18 +477,15 @@ java -Xmx1024m -jar %INSTALL_PATH/calabash.jar "$@"
 
   <target name="maven-dist" depends="init,compile-everything" description="generate Maven jars">
     <!-- build the main artifact -->
-      <jar destfile="${maven-jar}">
-          <manifest>
-              <attribute name="Built-By" value="${built.by}"/>
-              <attribute name="Implementation-Vendor" value="${implementation.vendor}"/>
-              <attribute name="Implementation-Title" value="${implementation.title}"/>
-              <attribute name="Implementation-Version" value="${dist-version}"/>
-              <attribute name="Main-Class" value="com.xmlcalabash.drivers.Main"/>
-              <attribute name="Class-Path" value="${run.classpath}"/>
-          </manifest>
-
-          <fileset dir="${build.dir}"/>
-      </jar>
+    <taskdef resource="aQute/bnd/ant/taskdef.properties"
+      classpath="osgi/bnd.jar"/>
+    <bnd
+      classpath="${build.dir}"
+      eclipse="false"
+      failok="false"
+      exceptions="true"
+      files="osgi/calabash.bnd"
+      output="${maven-jar}"/>
 
     <!-- build the javadoc artifact -->
     <javadoc sourcepath="src" destdir="${build.dir}/javadoc" />

--- a/maven-build.txt
+++ b/maven-build.txt
@@ -1,0 +1,53 @@
+
+This describes the steps necessary to release Calabash to the Maven Central repository.
+
+Initial setup
+=============
+
+Make sure you have GPG installed, and have distributed a key to the pool.sks-keyservers.net server
+    gpg --keyserver hkp://pool.sks-keyservers.net --send-keys [your key ID]
+
+Go to the Sonatype docs:
+    https://docs.sonatype.org/display/Repository/Sonatype+OSS+Maven+Repository+Usage+Guide
+
+Carry out these steps:
+
+    Section 2 - signing up for a Sonatype JIRA account
+    Section 3 - creating a JIRA ticket
+
+Download Ant Maven tasks from http://maven.apache.org/ant-tasks/download.html and put it into ~/.ant/lib/.
+
+Create an XML file at ~/.m2/settings.xml
+
+    <settings>
+      <servers>
+        <server>
+          <id>sonatype-nexus-snapshots</id>
+          <username>your-username</username>
+          <password>your-password</password>
+        </server>
+        <server>
+          <id>sonatype-nexus-staging</id>
+          <username>your-username</username>
+          <password>your-password</password>
+        </server>
+      </servers>
+      <profiles>
+        <profile>
+          <id>gpg</id>
+          <properties>
+            <gpg.passphrase>your-passphrase</gpg.passphrase>
+          </properties>
+        </profile>
+      </profiles>
+    </settings>
+
+Releasing to Maven
+==================
+
+Run "ant maven-stage" to build a release and deploy it to the Sonatype server.
+
+Go back to the Sonatype docs at https://docs.sonatype.org/display/Repository/Sonatype+OSS+Maven+Repository+Usage+Guide.
+Carry out section 8 - release.
+
+For the first release, also carry out section 9 - activate Central Sync

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.xmlcalabash</groupId>
+    <artifactId>xmlcalabash</artifactId>
+    <!-- This will be updated by Ant -->
+    <version>@version@</version>
+    <name>XML Calabash</name>
+    <description>XML Calabash - an implementation of XProc: An XML Pipeline Language</description>
+    <url>http://xmlcalabash.com/</url>
+    <packaging>jar</packaging>
+
+    <developers>
+        <developer>
+            <name>Norm Walsh</name>
+            <url>http://norman.walsh.name/</url>
+        </developer>
+    </developers>
+
+    <licenses>
+        <license>
+            <name>Common Development and Distribution License (CDDL) version 1.0</name>
+            <url>http://www.opensource.org/licenses/cddl1.txt</url>
+        </license>
+        <license>
+            <name>GNU General Public License version 2+</name>
+            <url>http://www.gnu.org/licenses/gpl-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <scm>
+        <connection>scm:git:git@github.com:ndw/xmlcalabash1.git</connection>
+        <url>https://github.com/ndw/xmlcalabash1.git</url>
+    </scm>
+
+    <dependencies>
+
+        <!--
+        Files in the Calabash lib directory, and current status in the dependency list below:
+
+        htmlparser-1.3.1.jar        - LATEST NOT IN MAVEN - used for the unescape markup step
+        saxon9he.jar                - DONE
+        jing.jar                    - DONE
+        isorelax.jar                - TRANSIENT (from jing)
+        commons-httpclient-3.1.jar  - DONE
+        commons-codec-1.6.jar       - TRANSIENT (from httpclient)
+        commons-logging-1.1.1.jar   - TRANSIENT (from httpclient)
+        tagsoup-1.2.jar             - DONE
+        xmlresolver.jar             - NOT NEEDED - not used currently - and from Norm, so could be added to Maven
+        msv.jar                     - NOT NEEDED - used by ValidateWithRNG, which is unused (ValidateJing preferred)
+        -->
+
+        <dependency>
+            <groupId>net.sf.saxon</groupId>
+            <artifactId>Saxon-HE</artifactId>
+            <version>9.4</version>
+        </dependency>
+
+        <!-- No need to specify commons-logging or commons-codec - they're transitive dependencies of commons-httpclient -->
+        <dependency>
+            <groupId>commons-httpclient</groupId>
+            <artifactId>commons-httpclient</artifactId>
+            <version>3.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.thaiopensource</groupId>
+            <artifactId>jing</artifactId>
+            <version>20091111</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.sf.saxon</groupId>
+                    <artifactId>saxon</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.ccil.cowan.tagsoup</groupId>
+            <artifactId>tagsoup</artifactId>
+            <version>1.2.1</version>
+        </dependency>
+
+        <!-- @todo nu.validator.htmlparser version 1.3.1 doesn't exist in Maven yet. Version 1.2.1 does. -->
+        <!--
+        <dependency>
+            <groupId>nu.validator.htmlparser</groupId>
+            <artifactId>htmlparser</artifactId>
+            <version>1.3.1</version>
+        </dependency>
+        -->
+
+    </dependencies>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>sonatype-nexus-snapshots</id>
+            <name>Sonatype Nexus Snapshots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        </snapshotRepository>
+        <repository>
+            <id>sonatype-nexus-staging</id>
+            <name>Nexus Release Repository</name>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
+
+</project>


### PR DESCRIPTION
Hi,

These changes enable Calabash to be deployed to Maven Central by running "ant maven-stage".

You'll also need to carry out some additional steps - signing up for an account on the Sonatype server, adding the appropriate Ant libraries, and so on - see the maven-build.txt for details.

If you'd rather not do those steps, let me know and I can deploy Calabash myself to Maven myself, but it would be better if you're able to do it (in particular, I don't have all the JARs at the moment to have a compile-everything work, so I've only tested with "compile").

Let me know if I can help with any of it - I'm by no means a Maven expert, but I've successfully deployed things to Maven Central before.

Inigo
