### PR TITLE
Propagate the p:error input in the Java exception

### DIFF
--- a/src/com/xmlcalabash/core/XProcException.java
+++ b/src/com/xmlcalabash/core/XProcException.java
@@ -196,6 +196,10 @@ public class XProcException extends RuntimeException {
         return step;
     }
 
+    public XdmNode getNode() {
+        return node;
+    }
+
     public SourceLocator getLocator() {
         XdmNode locNode = null;
         if (step != null) locNode = step.getNode();

--- a/src/com/xmlcalabash/functions/IterationPosition.java
+++ b/src/com/xmlcalabash/functions/IterationPosition.java
@@ -9,6 +9,7 @@ import net.sf.saxon.om.StructuredQName;
 import net.sf.saxon.om.SequenceIterator;
 import com.xmlcalabash.core.XProcRuntime;
 import com.xmlcalabash.core.XProcConstants;
+import com.xmlcalabash.core.XProcData;
 import com.xmlcalabash.core.XProcException;
 import com.xmlcalabash.runtime.XStep;
 import net.sf.saxon.tree.iter.SingletonIterator;
@@ -80,7 +81,8 @@ public class IterationPosition extends ExtensionFunctionDefinition {
     private class IterationPositionCall extends ExtensionFunctionCall {
         public SequenceIterator call(SequenceIterator[] arguments, XPathContext context) throws XPathException {
             XProcRuntime runtime = tl_runtime.get();
-            XStep step = runtime.getXProcData().getStep();
+            XProcData data = runtime.getXProcData();
+            XStep step = data.getStep();
             // FIXME: this can't be the best way to do this...
             // step == null in use-when
             if (step != null && !(step instanceof XCompoundStep)) {

--- a/src/com/xmlcalabash/io/ReadableDocument.java
+++ b/src/com/xmlcalabash/io/ReadableDocument.java
@@ -43,11 +43,11 @@ import java.util.Vector;
  * @author ndw
  */
 public class ReadableDocument implements ReadablePipe {
+    protected DocumentSequence documents = null;
+    protected String uri = null;
+    protected XProcRuntime runtime = null;
     private int pos = 0;
-    private DocumentSequence documents = null;
     private String base = null;
-    private String uri = null;
-    private XProcRuntime runtime = null;
     private XdmNode node = null;
     private boolean readDoc = false;
     private Step reader = null;
@@ -125,7 +125,7 @@ public class ReadableDocument implements ReadablePipe {
         return doc;
     }
 
-    private void readDoc() {
+    protected void readDoc() {
         XdmNode doc;
 
         readDoc = true;

--- a/src/com/xmlcalabash/library/Error.java
+++ b/src/com/xmlcalabash/library/Error.java
@@ -109,11 +109,7 @@ public class Error extends DefaultStep {
 
         step.reportError(treeWriter.getResult());
 
-        if (errorCode != null) {
-            throw new XProcException(errorCode, doc.getStringValue());
-        } else {
-            throw new XProcException();
-        }
+        throw new XProcException(errorCode, doc, doc.getStringValue());
     }
 }
 

--- a/src/com/xmlcalabash/model/Parser.java
+++ b/src/com/xmlcalabash/model/Parser.java
@@ -1395,6 +1395,7 @@ public class Parser {
                 }
             }
 
+System.err.println("step: " + step);
             step.checkPrimaryIO();
             rest = steps;
         }


### PR DESCRIPTION
For now, the XProcException thrown in Java for p:error does not include the step input.  The input _string value_ is used as the exception message, but the document itself is lost.  This change adds the document to the exception and makes it available to the exception user.
