### PR TITLE
Ant task for Calabash

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -23,7 +23,8 @@
   <property name="submit.username" value="calabash"/>
   <property name="submit.password" value=""/>
 
-  <property name="javac.debug" value="true"/>
+  <!-- Whether to include debugging information when compiling. -->
+  <property name="javac.debug" value="false"/>
 
   <property name="izpack.dir" value="/Applications/IzPack"/>
 
@@ -45,6 +46,7 @@
     <fileset dir="${lib.dir}">
       <include name="*.jar"/>
     </fileset>
+    <pathelement location="${ant.library.dir}/ant.jar"/>
   </path>
 
   <path id="full.classpath">
@@ -121,9 +123,8 @@
 
     <javac destdir="${build.dir}"
 	   classpathref="build.classpath"
-           includeantruntime="true"
-	   debug="${javac.debug}"
-	   debuglevel="lines,vars,source">
+           includeantruntime="false"
+	   debug="${javac.debug}">
       <!--
       <compilerarg value="-Xlint"/>
       -->

--- a/build.xml
+++ b/build.xml
@@ -23,6 +23,8 @@
   <property name="submit.username" value="calabash"/>
   <property name="submit.password" value=""/>
 
+  <property name="javac.debug" value="true"/>
+
   <property name="izpack.dir" value="/Applications/IzPack"/>
 
   <available property="izpack.present"
@@ -118,7 +120,9 @@
 
     <javac destdir="${build.dir}"
 	   classpathref="build.classpath"
-           includeantruntime="true">
+           includeantruntime="true"
+	   debug="${javac.debug}"
+	   debuglevel="lines,vars,source">
       <!--
       <compilerarg value="-Xlint"/>
       -->

--- a/build.xml
+++ b/build.xml
@@ -118,7 +118,7 @@
 
     <javac destdir="${build.dir}"
 	   classpathref="build.classpath"
-           includeantruntime="false">
+           includeantruntime="true">
       <!--
       <compilerarg value="-Xlint"/>
       -->

--- a/docs/src/anttask.xml
+++ b/docs/src/anttask.xml
@@ -1,0 +1,786 @@
+<chapter xmlns="http://docbook.org/ns/docbook"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xml:id="running" version="5.0">
+<title>Calabash Ant Task</title>
+
+<para>This chapter describes how to run <citetitle>XML
+Calabash</citetitle> from the Apache Ant using the
+<code>CalabashTask</code> custom task.</para>
+
+<section xml:id="antsetup">
+<title>Setting up the Ant Task</title>
+
+<para>Setting up is as for any other custom Ant task: you need a <markup>taskdef</markup>:</para>
+
+<programlisting>&lt;taskdef name="calabash"
+	   classname="com.xmlcalabash.drivers.CalabashTask"
+	   classpath="<replaceable>path/to</replaceable>/calabash.jar"/></programlisting>
+</section>
+
+<section>
+<title>Description</title>
+<para>Runs Calabash.  You can use this task to process:<itemizedlist>
+                                    <listitem>
+                                             <para>A single input file to produce a single output
+                                                  file</para>
+                                    </listitem>
+                                    <listitem>
+                                             <para>A set of input files, processed one at a time, to
+                                                  produce a set of output files</para>
+                                    </listitem>
+                                    <listitem>
+                                             <para>Multiple input files as the input to one XProc
+                                                  input port processed to produce a single output
+                                                  file</para>
+                                    </listitem>
+                                    <listitem>
+                                             <para>Any of the above with additional input ports to
+                                                  each of which are applied one or more input files
+                                                  whose file names may be either fixed or mapped
+                                                  from the name(s) of the current main input
+                                                  file(s)</para>
+                                    </listitem>
+                                    <listitem>
+                                             <para>Any of the above with additional output ports
+                                                  whose file names may be either fixed or mapped
+                                                  from the name(s) of the current main input
+                                                  file(s)</para>
+                                    </listitem>
+                           </itemizedlist></para>
+                  <para>You can also specify options and parameters to be used by the
+                           pipeline.</para>
+                  <section>
+                           <title>Input and output files and filesets</title>
+                           <para>In the simplest scenario, the <tag class="attribute">in</tag>
+                                    attribute, if present, specifies the single input file and/or
+                                    the <tag class="attribute">out</tag> attribute, if present,
+                                    specifies the single output file.  The <tag class="attribute"
+                                             >inport</tag> and <tag class="attribute">outport</tag>
+                                    attributes specify the pipeline port to which to apply the input
+                                    or from which to receive the output, respectively, though these
+                                    may be omitted as stated below.</para>
+                           <para>You can as well or instead specify one or more files to apply to an
+                                    input port using one or more nested <tag class="element"
+                                             >input</tag> elements.</para>
+                           <para><tag class="element">input</tag> elements whose <tag
+                                             class="attribute">port</tag> attribute value matches
+                                             <tag class="attribute">inport</tag> (or whose <tag
+                                             class="attribute">port</tag> attribute is omitted when
+                                             <tag class="attribute">inport</tag> is omitted) are
+                                    applied to the <tag class="attribute">inport</tag> port.  Those
+                                             <tag class="element">input</tag> elements may contain
+                                    zero or more elements selecting an Ant resource collection
+                                    (i.e., <tag class="element">fileset</tag>, <tag class="element"
+                                             >dirset</tag>, etc.) that may each select zero or more
+                                    files.</para>
+                           <para><tag class="element">input</tag> elements for ports other than the
+                                             <tag class="attribute">inport</tag> port may contain
+                                    either zero or more resource collection elements or an Ant
+                                    mapper element (i.e., <tag class="element">mapper</tag>, <tag
+                                             class="element">globmapper</tag>, etc.) that maps the
+                                    current <tag class="attribute">inport</tag> file(s) name(s) to
+                                    other file name(s) that are used as the input file(s) for that
+                                    port.  You cannot specify both resource collections and a mapper
+                                    for an input port (nor can you specify a mapper for the <tag
+                                             class="attribute">inport</tag> port).</para>
+                           <para>You can as well or instead specify a file to contain the output of
+                                    an output port using one or more nested <tag class="element"
+                                             >output</tag> elements. You cannot specify more than
+                                    one <tag class="element">output</tag> element for any pipeline
+                                    output.</para>
+                           <para>An <tag class="element">output</tag> element whose <tag
+                                             class="attribute">port</tag> attribute value matches
+                                             <tag class="attribute">outport</tag> (or whose <tag
+                                             class="attribute">port</tag> attribute is omitted when
+                                             <tag class="attribute">outport</tag> is omitted) is
+                                    used for the <tag class="attribute">outport</tag> port. This
+                                             <tag class="element">output</tag> element and the <tag
+                                             class="attribute">out</tag> attribute cannot both be
+                                    used at once.</para>
+                           <para>Other <tag class="element">output</tag> elements may each be used
+                                    for any of the other output ports of the pipeline.</para>
+                           <para><tag class="attribute">output</tag> elements may contain either
+                                    zero or more resource collection elements or an Ant mapper
+                                    element (i.e., <tag class="element">mapper</tag>, <tag
+                                             class="element">globmapper</tag>, etc.) that maps the
+                                    current <tag class="attribute">inport</tag> file(s) name(s) to a
+                                    file name that is used as the output file for that port.  You
+                                    cannot specify both resource collections and a mapper for an
+                                    output port, and the <tag class="element">output</tag> cannot
+                                    result in more than one file name.</para>
+                           <para>When no files are specified for either the <tag class="attribute"
+                                             >inport</tag> or <tag class="attribute">outport</tag>
+                                    ports, the implicit fileset (formed based on <tag
+                                             class="attribute">includes</tag> and other attributes
+                                    of <tag class="element">calabash</tag>) and/or an explicit file
+                                    set (formed from nested resource collection elements (outside of
+                                    any in <tag class="element">input</tag> or <tag class="element"
+                                             >output</tag> elements)) makes a set of files that are
+                                    processed one at a time as the input to the <tag
+                                             class="attribute">inport</tag> port in separate runs of
+                                    the pipeline.</para>
+                           <para>The <tag class="attribute">basedir</tag>, <tag class="attribute"
+                                             >includes</tag>, <tag class="attribute"
+                                             >includesfile</tag>, <tag class="attribute"
+                                             >excludes</tag>, <tag class="attribute"
+                                             >excludesfile</tag>, <tag class="attribute"
+                                             >defaultexcludes</tag>, and <tag class="attribute"
+                                             >scanincludeddirectories</tag> attributes determine the
+                                    implicit fileset.  <tag class="attribute"
+                                             >useimplicitfileset</tag> can disable the implicit
+                                    fileset.</para>
+                           <para>When the implicit fileset and/or the explicit fileset selects one
+                                    or more files, the <tag class="attribute">destdir</tag>, and
+                                             <tag class="attribute">extension</tag> attributes (or
+                                    using a nested mapper instead of <tag class="attribute"
+                                             >extension</tag>) determine the filename to use for the
+                                    output of the <tag class="attribute">outport</tag> port, and the
+                                    resource collections or mapper for other input and output ports
+                                    determine the file(s) from which to read or the file to which to
+                                    write for those ports.</para>
+                  </section>
+                  <section>
+                           <title>Ports</title>
+                           <para>The <tag class="attribute">inport</tag> and <tag class="attribute"
+                                             >outport</tag> attributes determine the pipeline ports
+                                    to use for single, or sequential, processing of files.
+                                    Additionally, the filename of the file on the <tag
+                                             class="attribute">inport</tag> port is used (or can be
+                                    used) by mappers to determine the input or output files to use
+                                    for other ports.</para>
+                           <para>You may omit at most one input port name and at most one output
+                                    port name from the ports specified on the <tag class="element"
+                                             >calabash</tag> task. The <tag class="element"
+                                             >calabash</tag> task maps the first input and output
+                                    ports of the pipeline that have no defined mapping to the
+                                    unnamed ports (and any additional port without a defined mapping
+                                    will cause an error). The omitted ports do not have to be the
+                                             <tag class="attribute">inport</tag> and <tag
+                                             class="attribute">outport</tag> ports; e.g., you can
+                                    instead specify <tag class="attribute">inport</tag> and omit the
+                                             <tag class="attribute">port</tag> attribute on the
+                                    nested <tag class="element">input</tag> element for a different
+                                    port. The omitted ports do not have to be the primary input and
+                                    output ports of the pipeline: matching is purely by name only
+                                    (or, rather, on the absence of a name).</para>
+                           <para>Nested <tag class="element">parameter</tag> elements specify Inputs
+                                    to parameter ports.</para>
+                  </section>
+</section>
+
+<section>
+<title>Parameters</title>
+                  <informaltable frame="border">
+                           <thead>
+                                    <tr>
+                                             <th>Attribute</th>
+                                             <th>Description</th>
+                                             <th>Required</th>
+                                    </tr>
+                           </thead>
+                           <tbody>
+                                    <tr>
+                                             <td>in</td>
+                                             <td>Location of a single XML file to process</td>
+                                             <td>No</td>
+                                    </tr>
+                                    <tr>
+                                             <td>inport</td>
+                                             <td>Pipeline input port ot which to apply
+                                                      <tag class="attribute">in</tag> file (or to apply files from
+                                                  implicit or explicit filesets)</td>
+                                             <td>No; the otherwise unmapped input port will be
+                                                  used</td>
+                                    </tr>
+                                    <tr>
+                                             <td>out</td>
+                                             <td>Specifies the output name for the result of the
+                                                  pipeline</td>
+                                             <td>No</td>
+                                    </tr>
+                                    <tr>
+                                             <td>outport</td>
+                                             <td>Pipeline output port that writes to out (or to
+                                                  outputs mapped from implicit and/or explicit input
+                                                  filesets)</td>
+                                             <td>No; the otherwise unmapped output port will be
+                                                  used</td>
+                                    </tr>
+                                    <tr>
+                                             <td>pipeline</td>
+                                             <td>XProc pipeline file</td>
+                                             <td>Yes, unless a nested <tag class="element">pipeline</tag> has
+                                                  been specified</td>
+                                    </tr>
+                                    <tr>
+                                             <td>useimplicitfileset</td>
+                                             <td>Whether to use the implicit fileset formed using
+                                                  includes, excludes, etc.</td>
+                                             <td>No; default is <literal>true</literal> unless
+                                                      <tag class="attribute">in</tag> or a nested
+                                                  <tag class="element">input</tag> corresponding to
+                                                      <markup>inport</markup> or <tag class="attribute">out</tag> or
+                                                  a nested <tag class="element">output</tag> corresponding to
+                                                  <markup>outport</markup> has been specified</td>
+                                    </tr>
+                                    <tr>
+                                             <td>basedir</td>
+                                             <td>Where to find the source XML when the implicit
+                                                  fileset is used</td>
+                                             <td>No</td>
+                                    </tr>
+                                    <tr>
+                                             <td>destdir</td>
+                                             <td>Where to store the results when the implicit
+                                                  fileset is used</td>
+                                             <td>No</td>
+                                    </tr>
+                                    <tr>
+                                             <td>extension</td>
+                                             <td>Desired file extension to use for outputs mapped
+                                                  from the implicit and/or explicit filesets</td>
+                                             <td>No; default is <literal>-out.xml</literal></td>
+                                    </tr>
+                                    <tr>
+                                             <td>includes</td>
+                                             <td>Comma- or space-separated list of patterns of files
+                                                  that must be included. All files are included when
+                                                  omitted. </td>
+                                             <td>No</td>
+                                    </tr>
+                                    <tr>
+                                             <td>includesfile</td>
+                                             <td>Name of a file, each line of which is taken as an
+                                                  include pattern</td>
+                                             <td>No</td>
+                                    </tr>
+                                    <tr>
+                                             <td>excludes</td>
+                                             <td>Comma- or space-separated list of patterns of files
+                                                  that must be excluded.  No files (except default
+                                                  excludes) are excluded when omtted.</td>
+                                             <td>No</td>
+                                    </tr>
+                                    <tr>
+                                             <td>excludesfile</td>
+                                             <td>Name of a file, each line of which is taken as an
+                                                  exclude pattern</td>
+                                             <td>No</td>
+                                    </tr>
+                                    <tr>
+                                             <td>defaultexcludes</td>
+                                             <td>Indicates whether default excludes should be used
+                                                  or not.  Default excludes are used when
+                                                  omitted.</td>
+                                             <td>No; default is <literal>true</literal></td>
+                                    </tr>
+                                    <tr>
+                                             <td>scanincludeddirectories</td>
+                                             <td>If any directories are matched by the
+                                                  includes/excludes patterns, try to process all
+                                                  files in those directories</td>
+                                             <td>No; default is <literal>true</literal></td>
+                                    </tr>
+                                    <tr>
+                                             <td>failonnoresources</td>
+                                             <td>Whether the build should fail if the explicit
+                                                  fileset from a nested resource collection is
+                                                  empty</td>
+                                             <td>No; default is <literal>false</literal></td>
+                                    </tr>
+                                    <tr>
+                                             <td>force</td>
+                                             <td>Run pipeline, even when outputs are newer than
+                                                  either inputs or pipeline.</td>
+                                             <td>No; default is <literal>false</literal></td>
+                                    </tr>
+                                    <tr>
+                                             <td>failonerror</td>
+                                             <td>Whether the build should fail if any errors
+                                                  occur</td>
+                                             <td>No; default is <literal>false</literal></td>
+                                    </tr>
+                                    <tr>
+                                             <td>debug</td>
+                                             <td>Whether to enable debugging output from
+                                                  Calabash</td>
+                                             <td>No; default is <literal>false</literal></td>
+                                    </tr>
+                                    <tr>
+                                             <td>generalvalues</td>
+                                             <td>Whether to enable general values.  See <uri
+                                                  xlink:href="extensions.html#ext.general-values"
+                                                  >http://xmlcalabash.com/docs/reference/extensions.html#ext.general-values</uri></td>
+                                             <td>No; default is <literal>false</literal></td>
+                                    </tr>
+                                    <tr>
+                                             <td>xpointerontext</td>
+                                             <td>Whether XPointer attributes on an XInclude element
+                                                  can be used when
+                                                  <markup>parse="text"</markup></td>
+                                             <td>No; default is <literal>false</literal></td>
+                                    </tr>
+                                    <tr>
+                                             <td>usexslt10</td>
+                                             <td>Whether to enable the use of XSLT 1.0</td>
+                                             <td>No; default is <literal>false</literal></td>
+                                    </tr>
+                                    <tr>
+                                             <td>transparentjson</td>
+                                             <td>Whether ot automatically translate between JSON and
+                                                  XML</td>
+                                             <td>No; default is <literal>false</literal></td>
+                                    </tr>
+                                    <tr>
+                                             <td>jsonflavor</td>
+                                             <td>Desired XML flavor</td>
+                                             <td>No</td>
+                                    </tr>
+                           </tbody>
+                  </informaltable>
+</section>
+         <section>
+                  <title>Parameters specified as nested elements</title>
+                  <section>
+                           <title>input</title>
+                           <para>Specification of resources to apply to an input port.  May specify
+                                    additional or alternative inputs to be applied to the
+                                    <tag class="attribute">inport</tag> port or may be fixed or mapped
+                                    resources to be applied to other ports.</para>
+                           <section>
+                                    <title>Parameters</title>
+                                    <informaltable frame="border">
+                                             <thead>
+                                                      <tr>
+                                                               <th>Attribute</th>
+                                                               <th>Description</th>
+                                                               <th>Required</th>
+                                                      </tr>
+                                             </thead>
+                                             <tbody>
+                                                      <tr>
+                                                               <td>port</td>
+                                                               <td>port name</td>
+                                                               <td>No; the otherwise unmapped input
+                                                                        port will be used</td>
+                                                      </tr>
+                                                      <tr>
+                                                               <td>if</td>
+                                                               <td>The port specification will be used if this
+                                                                        property is set</td>
+                                                               <td>No</td>
+                                                      </tr>
+                                                      <tr>
+                                                               <td>unless</td>
+                                                               <td>The port will not be used if this property is
+                                                                        set</td>
+                                                               <td>No</td>
+                                                      </tr></tbody>
+                                    </informaltable></section>
+                           <section>
+                                    <title>Parameters specified as nested elements</title>
+                                    <para>Either resource collections <emphasis>or</emphasis> a
+                                             mapper may be specified, but not both.</para>
+                                    <section>
+                                             <title>any resource collection</title>
+                                             <para>Use resource collections to specify
+                                                      fixed resources that should be applied to this
+                                                      port.</para>
+                                    </section>
+                                    <section>
+                                             <title>mapper</title>
+                                             <para>You can define resources to be used based on the
+                                                  resource(s) specified for the <tag
+                                                  class="attribute">inport</tag> port or on the
+                                                  current resource from the implicit and/or explicit
+                                                  input fileset.</para>
+                                             <para>You cannot use a mapper on the <tag class="attribute">inport</tag> port.</para>
+                                    </section>
+                           </section>
+                           
+                  </section>
+                  <section>
+                           <title>pipeline</title>
+                           <para>Pipeline file.  Can be used instead of <tag class="attribute"
+                                             >pipeline</tag>.</para>
+                           <section>
+                                    <title>Parameters specified as nested elements</title>
+                                    <section>
+                                             <title>any resource collection</title>
+                                             <para>Use resource collections to specify fixed
+                                                  resources that should be applied to this
+                                                  port.</para>
+                                    </section>
+                           </section>
+                  </section>
+                  <section>
+                           <title>output</title>
+                           <para>Specification of resources to which to write the output from an
+                                    output port. May be used as an alternative to <tag
+                                             class="attribute">out</tag> to specify to which to
+                                    write the output from the <tag class="attribute">outport</tag>
+                                    port or may be fixed or mapped resources to be applied to other
+                                    ports.</para>
+                           <section>
+                                    <title>Parameters</title>
+                                    <informaltable frame="border">
+                                             <thead>
+                                                  <tr>
+                                                  <th>Attribute</th>
+                                                  <th>Description</th>
+                                                  <th>Required</th>
+                                                  </tr>
+                                             </thead>
+                                             <tbody>
+                                                  <tr>
+                                                  <td>port</td>
+                                                  <td>port name</td>
+                                                  <td>No; the otherwise unmapped output port will be
+                                                  used</td>
+                                                  </tr>
+                                                  <tr>
+                                                  <td>if</td>
+                                                  <td>The port specification will be used if this
+                                                  property is set</td>
+                                                  <td>No</td>
+                                                  </tr>
+                                                  <tr>
+                                                  <td>unless</td>
+                                                  <td>The port will not be used if this property is
+                                                  set</td>
+                                                  <td>No</td>
+                                                  </tr>
+                                             </tbody>
+                                    </informaltable>
+                           </section>
+                           <section>
+                                    <title>Parameters specified as nested elements</title>
+                                    <para>Either resource collections <emphasis>or</emphasis> a
+                                             mapper may be specified, but not both.</para>
+                                    <section>
+                                             <title>any resource collection</title>
+                                             <para>Use resource collections to specify fixed
+                                                  resources that should be applied to this
+                                                  port.</para>
+                                    </section>
+                                    <section>
+                                             <title>mapper</title>
+                                             <para>You can define resources to which to write based
+                                                  on the resource(s) specified for the <tag
+                                                  class="attribute">inport</tag> port.</para>
+                                    </section>
+                           </section>
+                  </section>
+                  <section>
+                                    <title>any resource collection</title>
+                                    <para>Use resource collections to specify fixed resources that
+                                    should processed consecutively in a sequence of Calabash
+                                    runs.</para>
+                           </section>
+                           <section>
+                                    <title>mapper</title>
+                                    <para>You can define resources to which to write based on the
+                                    resource(s) specified for the implicit fileset (based on <tag
+                                             class="attribute">includes</tag>, etc.) and/or on the
+                                    explicit fileset formed from resource collections that are
+                                    children of <tag class="element">calabash</tag>.</para>
+                           </section>
+                  <section>
+                                    <title>namespace</title>
+                           <para>Use nested <tag class="element">namespace</tag> elements to define
+                                    mappings between prefixes and namespace URIs for any prefixes
+                                    that are used in <tag class="element">option</tag> or <tag
+                                             class="element">parameter</tag> elements.</para>
+                           <informaltable frame="border">
+                                    <thead>
+                                             <tr>
+                                                      <th>Attribute</th>
+                                                      <th>Description</th>
+                                                      <th>Required</th>
+                                             </tr>
+                                    </thead>
+                                    <tbody>
+                                             <tr>
+                                                      <td>prefix</td>
+                                                  <td>Prefix to which to map the URI</td>
+                                                      <td>Yes</td>
+                                             </tr>
+                                             <tr>
+                                                      <td>uri</td>
+                                                      <td>Namespace uri</td>
+                                                      <td>Yes</td>
+                                             </tr>
+                                    </tbody>
+                           </informaltable></section>
+                  <section>
+                           <title>option</title>
+                           <para>Specifies an option to be passed to the XProc processor</para>
+                           <section>
+                                    <title>Parameters</title>
+                                    <informaltable frame="border">
+                                             <thead>
+                                                      <tr>
+                                                               <th>Attribute</th>
+                                                               <th>Description</th>
+                                                               <th>Required</th>
+                                                      </tr>
+                                             </thead>
+                                             <tbody>
+                                                      <tr>
+                                                               <td>name</td>
+                                                               <td>Option name, which must be
+                                                  unique. QNames have their prefix matched against
+                                                  bindings specified in <tag class="element"
+                                                  >namespace</tag> elements. QNames may also be
+                                                  specified in Clark notation, e.g.,
+                                                  <literal>{uri}name</literal>.</td>
+                                                               <td>No</td>
+                                                      </tr>
+                                                      <tr>
+                                                               <td>value</td>
+                                                               <td>Option string value</td>
+                                                               <td>No</td>
+                                                      </tr>
+                                                      <tr>
+                                                               <td>if</td>
+                                                               <td>The option specification will be used if this
+                                                                        property is set</td>
+                                                               <td>No</td>
+                                                      </tr>
+                                                      <tr>
+                                                               <td>unless</td>
+                                                               <td>The option will not be used if this property
+                                                                        is set</td>
+                                                               <td>No</td>
+                                                      </tr>
+                                             </tbody>
+                                    </informaltable>
+                           </section>
+                  </section>
+                  <section>
+                           <title>param</title>
+                           <para>Specifies a parameter to be passed to the XProc processor</para>
+                           <section>
+                                    <title>Parameters</title>
+                                    <informaltable frame="border">
+                                             <thead>
+                                                      <tr>
+                                                               <th>Attribute</th>
+                                                               <th>Description</th>
+                                                               <th>Required</th>
+                                                      </tr>
+                                             </thead>
+                                             <tbody>
+                                                      <tr>
+                                                               <td>port</td>
+                                                               <td>Port to which to apply the
+                                                  parameter.</td>
+                                                               <td>No; default is the primary
+                                                  parameter port</td>
+                                                      </tr>
+                                                      <tr>
+                                                               <td>name</td>
+                                                               <td>Parameter name name, which must
+                                                  be unique. QNames have their prefix matched
+                                                  against bindings specified in <tag class="element"
+                                                  >namespace</tag> elements. QNames may also be
+                                                  specified in Clark notation, e.g.,
+                                                  <literal>{uri}name</literal>.</td>
+                                                               <td>No</td>
+                                                      </tr>
+                                                      <tr>
+                                                               <td>value</td>
+                                                               <td>Parameter string value</td>
+                                                               <td>No</td>
+                                                      </tr>
+                                                      <tr>
+                                                               <td>if</td>
+                                                               <td>The option specification will be used if this
+                                                                        property is set</td>
+                                                               <td>No</td>
+                                                      </tr>
+                                                      <tr>
+                                                               <td>unless</td>
+                                                               <td>The option will not be used if this property
+                                                                        is set</td>
+                                                               <td>No</td>
+                                                      </tr>
+                                             </tbody>
+                                    </informaltable>
+                           </section>
+                  </section>
+                  <section><title>sysproperty</title>
+                           <para>Specify Java system properties used by Calabash</para></section>
+                  <section><title>syspropertyset</title>
+                           <para>Specify sets of Java system properties used by Calabash</para></section>
+         </section>
+         <section>
+                  <title>Examples</title>
+                  <section>
+                           <title>Single input, single output</title>
+                           <programlisting>&lt;calabash in="in.xml" out="out1.xml" pipeline="pipeline.xpl"/></programlisting>
+                           <para>What could be simpler?</para>
+                  </section>
+                  <section>
+                           <title><tag class="element">pipeline</tag></title>
+                           <programlisting>&lt;calabash in="in.xml" out="out.xml">
+  &lt;pipeline>
+    &lt;file file="pipeline.xpl" />
+  &lt;/pipeline>
+&lt;/calabash></programlisting>
+                  </section>
+                  <section>
+                           <title>Implicit fileset plus mapper on additional input port</title>
+                           <programlisting>&lt;calabash includes="doc.xml"
+	      inport="source"
+	      destdir="out"
+	      extension=".compare.xml"
+	      pipeline="compare-001.xpl">
+      &lt;input port="alternate">
+	&lt;globmapper from="*.xml" to="*-alt.xml" />
+      &lt;/input>
+&lt;/calabash></programlisting>
+                  </section>
+                  <section>
+                           <title>Fixed input, multiple mapped outputs</title>
+                           <programlisting>&lt;calabash in="group-003_input1.xml" pipeline="group-003_pipeline.xpl">
+      &lt;output port="result">
+	&lt;globmapper from="*_input1.xml" to="out/*_result.xml" />
+      &lt;/output>
+      &lt;output port="result2">
+	&lt;globmapper from="*_input1.xml" to="out/*_result2.xml" />
+      &lt;/output>
+&lt;/calabash></programlisting>
+                  </section>
+                  <section>
+                           <title>QNames</title>
+                           <programlisting>&lt;calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+      &lt;sysproperty key="com.xmlcalabash.phonehome" value="false" />
+      &lt;namespace prefix="hi" uri="low" />
+      &lt;parameter name="{hi}there" value="a value" />
+      &lt;parameter name="hi:there" value="a value" />
+&lt;/calabash></programlisting>
+                           <para><literal>{hi}there</literal> is a QName in Clark notation, where
+                                             <literal>hi</literal> is the namespace URI and
+                                             <literal>there</literal> is the local name; whereas
+                                             <literal>hi</literal> in <literal>hi:there</literal> is
+                                    a namespace prefix that is bound to the <literal>low</literal>
+                                    namespace URI.</para>
+                  </section>
+         </section>
+         <section>
+                  <title>What not to do</title>
+                  <variablelist>
+                           <varlistentry>
+                                    <term>Multiple pipelines</term>
+                                    <listitem>
+                                             <para>Too conflicted</para>
+                                    </listitem>
+                           </varlistentry>
+                           <varlistentry>
+                                    <term>Non-existent file for <tag class="attribute">in</tag> or
+                                                  <tag class="attribute">pipeline</tag> (or <tag
+                                                  class="element">pipeline</tag>)</term>
+                                    <listitem>
+                                             <para>When there's only one of each, it's a problem if
+                                                  they don't actually exist</para>
+                                    </listitem>
+                           </varlistentry>
+                           <varlistentry>
+                                    <term><tag class="attribute">in</tag> and/or <tag
+                                                  class="attribute">out</tag> and an implicit
+                                             fileset</term>
+                                    <listitem>
+                                             <para>The implicit fileset is ignored (and, when the
+                                                  log level is <literal>verbose</literal>, a message
+                                                  is emitted)</para>
+                                    </listitem>
+                           </varlistentry>
+                           <varlistentry>
+                                    <term>Two or more of <tag class="attribute">out</tag>, a
+                                             resource for <tag class="attribute">outport</tag>, a
+                                             mapper for <tag class="attribute">outport</tag>, and
+                                                  <tag class="attribute">extension</tag></term>
+                                    <listitem>
+                                             <para>Too conflicted</para>
+                                    </listitem>
+                           </varlistentry>
+                           <varlistentry>
+                                    <term>Duplicate parameter QNames for the same port or duplicate
+                                             option QNames</term>
+                                    <listitem>
+                                             <para>Too conflicted</para>
+                                    </listitem>
+                           </varlistentry>
+                           <varlistentry>
+                                    <term>Pipeline input port with no explicit binding (or more than
+                                             one when one <tag class="element">calabash</tag> input
+                                             port is unnamed)</term>
+                                    <listitem>
+                                             <para>No input is applied to the port.</para>
+                                             <para>When one <tag class="element">calabash</tag> port
+                                                  is unnamed and more than one pipeline input port
+                                                  has no explicit binding, one of the unbound
+                                                  pipeline ports is mapped to the unnamed port, but
+                                                  you can't control which pipeline port.</para>
+                                    </listitem>
+                           </varlistentry>
+                           <varlistentry>
+                                    <term>Pipeline output port with no explicit binding (or more
+                                             than one when one <tag class="element">calabash</tag>
+                                             output port is unnamed)</term>
+                                    <listitem>
+                                             <para>The pipeline output on that port is
+                                                  discarded</para>
+                                             <para>When one <tag class="element">calabash</tag>
+                                                  output port is unnamed and more than one pipeline
+                                                  output port has no explicit binding, one of the
+                                                  unbound pipeline ports is mapped to the unnamed
+                                                  port, but you can't control which pipeline
+                                                  port.</para>
+                                    </listitem>
+                           </varlistentry><varlistentry>
+                                    <term>Resources and mapper on same port</term>
+                                    <listitem>
+                                             <para>Too conflicted</para>
+                                    </listitem>
+                           </varlistentry>
+                           <varlistentry>
+                                    <term>Multiple mappers for one port</term>
+                                    <listitem>
+                                             <para>Too conflicted</para>
+                                    </listitem>
+                           </varlistentry>
+                           <varlistentry>
+                                    <term>Mapper on main input port</term>
+                                    <listitem>
+                                             <para>The file(s) on the main input port, determined by
+                                                      the <tag class="attribute">inport</tag> value,
+                                                      provides the name that other mappers use as their
+                                                      basis. A mapper on the main input port has nothing
+                                                      to use as a basis, so it's not allowed.</para>
+                                    </listitem>
+                           </varlistentry>
+                           <varlistentry>
+                                    <term>Multiple specifications for an output port or output port
+                                             resource collections or mappers that resolve to more
+                                             than one filename</term>
+                                    <listitem>
+                                             <para>The outputs of a pipeline run are each directed
+                                                      to at most one file</para>
+                                    </listitem>
+                           </varlistentry>
+                           <varlistentry>
+                                    <term><tag class="element">namespace</tag> without <tag
+                                             class="attribute">prefix</tag> or without <tag
+                                                      class="attribute">uri</tag></term>
+                                    <listitem>
+                                             <para><tag class="element">namespace</tag> is for
+                                                  mapping prefixes to URIs</para>
+                                    </listitem>
+                           </varlistentry>
+                           
+                  </variablelist>
+         </section>
+</chapter>

--- a/src/com/xmlcalabash/drivers/CalabashTask.java
+++ b/src/com/xmlcalabash/drivers/CalabashTask.java
@@ -613,66 +613,66 @@ public class CalabashTask extends MatchingTask {
 
     /** Do the work. */
     public void execute() {
+	Resource usePipelineResource = null;
+	if (pipelineURI != null) {
+	    // If we enter here, it means that the pipeline is supplied
+	    // via 'pipeline' attribute
+	    File pipelineFile = getProject().resolveFile(pipelineURI);
+	    FileResource fr = new FileResource();
+	    fr.setProject(getProject());
+	    fr.setFile(pipelineFile);
+	    usePipelineResource = fr;
+	} else {
+	    usePipelineResource = pipelineResource;
+	}
+
+	if (!usePipelineResource.isExists()) {
+	    handleError("pipeline '" + usePipelineResource.getName() + "' does not exist");
+	    return;
+	}
+
+	if (inResource != null && !inResource.isExists()) {
+	    handleError("input file '" + inResource.getName() + "' does not exist");
+	    return;
+	}
+
+	if (inResource != null && resources.size() != 0) {
+	    handleError("'in' and explicit filesets cannot be used together.");
+	    return;
+	}
+
+	if ((inResource != null || outResource != null) && useImplicitFileset) {
+	    log("'in' and/or 'out' cannot be used with implicit fileset: ignoring implicit fileset.", Project.MSG_VERBOSE);
+	    useImplicitFileset = false;
+	}
+
+	if (outResource != null && mapper != null) {
+	    handleError("Nested <mapper> for default output and 'out' cannot be used together.");
+	    return;
+	}
+
+	if ((outputMappers.containsKey(outPort) ||
+	     outputResources.containsKey(outPort)) &&
+	    mapper != null) {
+	    handleError("Nested <mapper> and port for default output cannot be used together.");
+	    return;
+	}
+
+	if (outResource != null && isTargetExtensionSet) {
+	    handleError("'extension' and 'out' cannot be used together.");
+	    return;
+	}
+
+	if (isTargetExtensionSet && mapper != null) {
+	    handleError("'extension' and nested <mapper> cannot be used together.");
+	    return;
+	}
+
 	File savedBaseDir = baseDir;
 
         try {
 	    if (baseDir == null) {
 		baseDir = getProject().getBaseDir();
-	    }
-
-	    Resource usePipelineResource = null;
-	    if (pipelineURI != null) {
-		// If we enter here, it means that the pipeline is supplied
-		// via 'pipeline' attribute
-		File pipelineFile = getProject().resolveFile(pipelineURI);
-		FileResource fr = new FileResource();
-		fr.setProject(getProject());
-		fr.setFile(pipelineFile);
-		usePipelineResource = fr;
-	    } else {
-		usePipelineResource = pipelineResource;
-	    }
-
-	    if (!usePipelineResource.isExists()) {
-		handleError("pipeline '" + usePipelineResource.getName() + "' does not exist");
-		return;
-	    }
-
-	    if (inResource != null && !inResource.isExists()) {
-		handleError("input file '" + inResource.getName() + "' does not exist");
-		return;
-	    }
-
-	    if (inResource != null && resources.size() != 0) {
-		handleError("'in' and explicit filesets cannot be used together.");
-		return;
-	    }
-
-	    if ((inResource != null || outResource != null) && useImplicitFileset) {
-		log("'in' and/or 'out' cannot be used with implicit fileset: ignoring implicit fileset.", Project.MSG_VERBOSE);
-		useImplicitFileset = false;
-	    }
-
-	    if (outResource != null && mapper != null) {
-		handleError("Nested <mapper> for default output and 'out' cannot be used together.");
-		return;
-	    }
-
-	    if ((outputMappers.containsKey(outPort) ||
-		 outputResources.containsKey(outPort)) &&
-		mapper != null) {
-		handleError("Nested <mapper> and port for default output cannot be used together.");
-		return;
-	    }
-
-	    if (outResource != null && isTargetExtensionSet) {
-		handleError("'extension' and 'out' cannot be used together.");
-		return;
-	    }
-
-	    if (isTargetExtensionSet && mapper != null) {
-		handleError("'extension' and nested <mapper> cannot be used together.");
-		return;
 	    }
 
 	    if (sysProperties.size() > 0) {
@@ -819,7 +819,7 @@ public class CalabashTask extends MatchingTask {
 			optionsMap,
 			parametersTable,
 			force);
-		return;
+		//return;
 	    } else { // Using implicit and/or explicit filesets
 		if (useImplicitFileset) {
 		    DirectoryScanner scanner = getDirectoryScanner(baseDir);
@@ -923,7 +923,7 @@ public class CalabashTask extends MatchingTask {
 	    }
 	} finally {
 	    // Same instance is reused when Ant runs this task
-	    // multiple times, so reset everything.
+	    // again, so reset everything.
 	    inputResources.clear();
 	    inputMappers.clear();
 	    outputResources.clear();

--- a/src/com/xmlcalabash/drivers/CalabashTask.java
+++ b/src/com/xmlcalabash/drivers/CalabashTask.java
@@ -6,79 +6,274 @@ import com.xmlcalabash.model.Serialization;
 import com.xmlcalabash.io.ReadablePipe;
 import com.xmlcalabash.io.WritableDocument;
 import com.xmlcalabash.runtime.XPipeline;
-import com.xmlcalabash.util.S9apiUtils;
 
+import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Task;
 import org.apache.tools.ant.BuildException;
-import org.xml.sax.XMLReader;
-import org.xml.sax.helpers.XMLReaderFactory;
-import org.xml.sax.InputSource;
+import org.apache.tools.ant.types.Mapper;
+import org.apache.tools.ant.types.ResourceCollection;
+import org.apache.tools.ant.types.Resource;
+import org.apache.tools.ant.types.resources.FileResource;
+import org.apache.tools.ant.types.resources.Resources;
+import org.apache.tools.ant.types.resources.Union;
+import org.apache.tools.ant.util.FileNameMapper;
 
-import net.sf.saxon.s9api.DocumentBuilder;
 import net.sf.saxon.s9api.QName;
 import net.sf.saxon.s9api.XdmNode;
 
+import java.io.File;
 import java.io.FileOutputStream;
 import java.net.URI;
 import java.util.*;
-import javax.xml.transform.sax.SAXSource;
+import org.xml.sax.InputSource;
 
 /**
- * The task of the tutorial.
- * Prints a message or let the build fail.
- * @author Jan Materne
- * @since 2003-08-19
+ * Ant task to run Calabash.
+ * @author MenteaXML
  */
 public class CalabashTask extends Task {
 
-    /** The message to print. As attribute. */
-    String message;
-    public void setMessage(String msg) {
-        message = msg;
+    /** Port of the pipeline input. As attribute. */
+    private String inPort;
+    public void setinPort(String port) {
+        inPort = port;
     }
 
-    /** Should the build fail? Defaults to <i>false</i>. As attribute. */
-    boolean fail = false;
-    public void setFail(boolean b) {
-        fail = b;
+    /** URI of the input XML. As attribute. */
+    private Resource inResource;
+    public void setIn(Resource inResource) {
+        this.inResource = inResource;
     }
 
-    /** Support for nested text. */
-    public void addText(String text) {
-        message = text;
+    /** URI of the pipeline to run. As attribute. */
+    String pipelineURI;
+    public void setPipeline(String uri) {
+        pipelineURI = uri;
     }
+
+    /** Pipeline as a {@link org.apache.tools.ant.types.Resource} */
+    private Resource pipelineResource = null;
+    /**
+     * API method to set the pipeline Resource.
+     * @param pipelineResource Resource to set as the pipeline.
+     */
+    public void setPipelineResource(Resource pipelineResource) {
+ 	this.pipelineResource = pipelineResource;
+    }
+
+    /**
+     * Add a nested &lt;pipeline&gt; element.
+     * @param rc the configured Resources object represented as &lt;pipeline&gt;.
+     */
+    public void addConfiguredPipeline(Resources rc) {
+ 	if (rc.size() != 1) {
+	    throw new BuildException("The pipeline element must be specified with exactly one"
+			+ " nested resource.");
+ 	} else {
+	    setPipelineResource((Resource) rc.iterator().next());
+ 	}
+    }
+
+    /** Port of the pipeline output. As attribute. */
+    String outPort;
+    public void setOutPort(String port) {
+        outPort = port;
+    }
+
+    /** Resource of the output XML. As attribute. */
+    Resource outResource;
+    public void setOut(Resource outResource) {
+        this.outResource = outResource;
+    }
+
+    /** Whether to fail the build if an error occurs. */
+    private boolean failOnError = true;
+    /**
+     * Whether any errors should make the build fail.
+     */
+    public void setFailOnError(boolean b) {
+        failOnError = b;
+    }
+
+    /**
+     * Additional resource collections to process.
+     */
+    private Union resources = new Union();
+
+    /**
+     * Whether to use the implicit fileset.
+     */
+    private boolean useImplicitFileset = true;
+    /**
+     * Whether to use the implicit fileset.
+     *
+     * <p>Set this to false if you want explicit control with nested
+     * resource collections.</p>
+     * @param useimplicitfileset set to true if you want to use implicit fileset
+     */
+    public void setUseImplicitFileset(boolean useimplicitfileset) {
+        useImplicitFileset = useimplicitfileset;
+    }
+
+    /**
+     * Adds a collection of resources to style in addition to the
+     * given file or the implicit fileset.
+     *
+     * @param rc the collection of resources to style
+     * @since Ant 1.7
+     */
+    public void add(ResourceCollection rc) {
+        resources.add(rc);
+    }
+
+    /**
+     * Mapper to use when a set of files gets processed.
+     */
+    private Mapper mapperElement = null;
+
+    /**
+     * Defines the mapper to map source to destination files.
+     * @param mapper the mapper to use
+     * @exception BuildException if more than one mapper is defined
+     */
+    public void addMapper(Mapper mapper) {
+        if (mapperElement != null) {
+            handleError("Cannot define more than one mapper");
+        } else {
+            mapperElement = mapper;
+        }
+    }
+
+    /**
+     * Adds a nested filenamemapper.
+     * @param fileNameMapper the mapper to add
+     * @exception BuildException if more than one mapper is defined
+     */
+    public void add(FileNameMapper fileNameMapper) throws BuildException {
+       Mapper mapper = new Mapper(getProject());
+       mapper.add(fileNameMapper);
+       addMapper(mapper);
+    }
+
+    /** force output of target files even if they already exist */
+    private boolean force = false;
+    /**
+     * Set whether to check dependencies, or always generate;
+     * optional, default is false.
+     *
+     * @param force true if always generate.
+     */
+    public void setForce(boolean force) {
+        this.force = force;
+    }
+
 
 
     /** Do the work. */
     public void execute() {
+	Resource usePipelineResource;
+	if (pipelineURI != null) {
+	    // If we enter here, it means that the pipeline is supplied
+	    // via 'pipeline' attribute
+	    File pipelineFile = getProject().resolveFile(pipelineURI);
+	    FileResource fr = new FileResource();
+	    fr.setProject(getProject());
+	    fr.setFile(pipelineFile);
+	    usePipelineResource = fr;
+	} else {
+	    usePipelineResource = pipelineResource;
+	}
+
+	if (!usePipelineResource.isExists()) {
+	    handleError("pipeline file " + usePipelineResource.getName() + " does not exist");
+	    return;
+	}
+
+	if (inResource != null && !inResource.isExists()) {
+	    handleError("input file " + inResource.getName() + " does not exist");
+	    return;
+	}
+	if (outResource == null) {
+	    handleError("'out' must be specified.");
+	    return;
+	}
+
+	// if we have an in file and out then process them
+	if (inResource != null && outResource != null) {
+	    process(inResource, outResource, usePipelineResource);
+	    return;
+	}
+    }
+
+    /**
+     * Process the input file to the output file with the given pipeline.
+     *
+     * @param inResource the input file to process.
+     * @param outFile the destination file.
+     * @param pipeline the pipeline to use.
+     * @exception BuildException if the processing fails.
+     */
+    private void process(Resource in, Resource out, Resource pipelineResource) throws BuildException {
+
+	long pipelineLastModified = pipelineResource.getLastModified();
+	log("In file " + in + " time: " + in.getLastModified(), Project.MSG_DEBUG);
+	log("Out file " + out + " time: " + out.getLastModified(), Project.MSG_DEBUG);
+	log("Style file " + pipelineResource + " time: " + pipelineLastModified, Project.MSG_DEBUG);
+
+	if (!force && in.getLastModified() < out.getLastModified()
+                    && pipelineLastModified < out.getLastModified()) {
+	    log("Skipping input file " + in + " because it is older than output file "
+		+ out + " and so is the stylesheet " + pipelineResource, Project.MSG_DEBUG);
+	    return;
+	}
+
+	log("Processing " + in + " to " + out, Project.MSG_INFO);
         XProcConfiguration config = new XProcConfiguration("he", false);
         XProcRuntime runtime = new XProcRuntime(config);
 
 	try {
-	    XPipeline pipeline = runtime.load("pipeline.xpl");
-	    XdmNode doc = runtime.parse(new InputSource("in.xml"));
-	    pipeline.writeTo("source", doc);
+	    XPipeline pipeline =
+		runtime.load(pipelineResource.getName());
+	    XdmNode doc = runtime.parse(new InputSource(in.getInputStream()));
+
+            Set<String> ports = pipeline.getInputs();
+            for (String port : ports) {
+                if (inPort == null) {
+                    inPort = port;
+		} else if (!port.equals(inPort)) {
+		    log("You didn't specify any binding for the input port '" + port + "'.", Project.MSG_WARN);
+                }
+            }
+
+	    if (!ports.contains(inPort)) {
+		handleError("There is a binding for the port '" + inPort + "' but the pipeline declares no such port.");
+		return;
+	    }
+
+	    pipeline.writeTo(inPort, doc);
 	    pipeline.run();
+
+            // Look for primary output port
+            for (String port : pipeline.getOutputs()) {
+                if (outPort == null) {
+                    outPort = port;
+		} else if (!port.equals(outPort)) {
+		    log("You didn't specify any binding for the output port '" + port + "', its output will be discarded.", Project.MSG_WARN);
+                }
+            }
 
             for (String port : pipeline.getOutputs()) {
                 String uri = null;
-		/*
-                if (cmd.outputs.containsKey(port)) {
-                    uri = cmd.outputs.get(port);
-                } else if (config.outputs.containsKey(port)) {
-                    uri = config.outputs.get(port);
+
+                if (outPort.equals(port)) {
+                    uri = outResource.getName();
                 }
 
-                if (port.equals(stdio)) {
-                    finest(logger, null, "Copy output from " + port + " to stdout");
-                    uri = null;
-                } else if (uri == null) {
+                if (uri == null) {
                     // You didn't bind it, and it isn't going to stdout, so it's going into the bit bucket.
                     continue;
-                } else {
-                    finest(logger, null, "Copy output from " + port + " to " + uri);
                 }
-		*/
+
                 Serialization serial = pipeline.getSerialization(port);
 
                 if (serial == null) {
@@ -108,7 +303,7 @@ public class CalabashTask extends Task {
                     }
                 }
 
-                // I wonder if there's a better way...
+                // ndw wonders if there's a better way...
                 WritableDocument wd = null;
                 if (uri != null) {
                     URI furi = new URI(uri);
@@ -129,41 +324,33 @@ public class CalabashTask extends Task {
                 }
             }
 	} catch (Exception err) {
-	    throw new BuildException("Pipeline failed: " + err.toString(), err);
+	    handleError("Pipeline failed: " + err.toString());
 	}
-        // handle attribute 'fail'
-        if (fail) throw new BuildException("Fail requested.");
+    }
 
-        // handle attribute 'message' and nested text
-        if (message!=null) log(message);
-
-        // handle nested elements
-        for (Iterator it=messages.iterator(); it.hasNext(); ) {
-            Message msg = (Message)it.next();
-            log(msg.getMsg());
+    /**
+     * Throws an exception with the given message if failOnError is
+     * true, otherwise logs the message using the WARN level.
+     */
+    protected void handleError(String msg) {
+        if (failOnError) {
+            throw new BuildException(msg, getLocation());
         }
+        log(msg, Project.MSG_WARN);
     }
 
 
-    /** Store nested 'message's. */
-    Vector messages = new Vector();
-
-    /** Factory method for creating nested 'message's. */
-    public Message createMessage() {
-        Message msg = new Message();
-        messages.add(msg);
-        return msg;
-    }
-
-    /** A nested 'message'. */
-    public class Message {
-        // Bean constructor
-        public Message() {}
-
-        /** Message to print. */
-        String msg;
-        public void setMsg(String msg) { this.msg = msg; }
-        public String getMsg() { return msg; }
+    /**
+     * Throws an exception with the given nested exception if
+     * failOnError is true, otherwise logs the message using the WARN
+     * level.
+     */
+    protected void handleError(Throwable ex) {
+        if (failOnError) {
+            throw new BuildException(ex);
+        } else {
+            log("Caught an exception: " + ex, Project.MSG_WARN);
+        }
     }
 
 }

--- a/src/com/xmlcalabash/drivers/CalabashTask.java
+++ b/src/com/xmlcalabash/drivers/CalabashTask.java
@@ -31,13 +31,6 @@ import javax.xml.transform.sax.SAXSource;
  */
 public class CalabashTask extends Task {
 
-    private Hashtable<String, Vector<XdmNode>> inputs = new Hashtable<String, Vector<XdmNode>>();
-    private Hashtable<String, Vector<XdmNode>> outputs = new Hashtable<String, Vector<XdmNode>>();
-    private Hashtable<QName, String> parameters = new Hashtable<QName, String>();
-    private Hashtable<QName, String> options = new Hashtable<QName, String>();
-    private XProcRuntime runtime = null;
-
-
     /** The message to print. As attribute. */
     String message;
     public void setMessage(String msg) {
@@ -59,21 +52,7 @@ public class CalabashTask extends Task {
     /** Do the work. */
     public void execute() {
         XProcConfiguration config = new XProcConfiguration("he", false);
-        runtime = new XProcRuntime(config);
-
-	try {
-	    InputSource isource = new InputSource("in.xml");
-	    XMLReader reader = XMLReaderFactory.createXMLReader();
-	    reader.setEntityResolver(runtime.getResolver());
-	    SAXSource source = new SAXSource(reader, isource);
-	    DocumentBuilder builder = runtime.getProcessor().newDocumentBuilder();
-	    builder.setLineNumbering(true);
-	    builder.setDTDValidation(false);
-	    XdmNode doc = builder.build(source);
-	    XdmNode root = S9apiUtils.getDocumentElement(doc);
-	} catch (Exception sae) {
-	    throw new BuildException("Fail requested.");
-	}
+        XProcRuntime runtime = new XProcRuntime(config);
 
 	try {
 	    XPipeline pipeline = runtime.load("pipeline.xpl");

--- a/src/com/xmlcalabash/drivers/CalabashTask.java
+++ b/src/com/xmlcalabash/drivers/CalabashTask.java
@@ -1,0 +1,190 @@
+package com.xmlcalabash.drivers;
+
+import com.xmlcalabash.core.XProcConfiguration;
+import com.xmlcalabash.core.XProcRuntime;
+import com.xmlcalabash.model.Serialization;
+import com.xmlcalabash.io.ReadablePipe;
+import com.xmlcalabash.io.WritableDocument;
+import com.xmlcalabash.runtime.XPipeline;
+import com.xmlcalabash.util.S9apiUtils;
+
+import org.apache.tools.ant.Task;
+import org.apache.tools.ant.BuildException;
+import org.xml.sax.XMLReader;
+import org.xml.sax.helpers.XMLReaderFactory;
+import org.xml.sax.InputSource;
+
+import net.sf.saxon.s9api.DocumentBuilder;
+import net.sf.saxon.s9api.QName;
+import net.sf.saxon.s9api.XdmNode;
+
+import java.io.FileOutputStream;
+import java.net.URI;
+import java.util.*;
+import javax.xml.transform.sax.SAXSource;
+
+/**
+ * The task of the tutorial.
+ * Prints a message or let the build fail.
+ * @author Jan Materne
+ * @since 2003-08-19
+ */
+public class CalabashTask extends Task {
+
+    private Hashtable<String, Vector<XdmNode>> inputs = new Hashtable<String, Vector<XdmNode>>();
+    private Hashtable<String, Vector<XdmNode>> outputs = new Hashtable<String, Vector<XdmNode>>();
+    private Hashtable<QName, String> parameters = new Hashtable<QName, String>();
+    private Hashtable<QName, String> options = new Hashtable<QName, String>();
+    private XProcRuntime runtime = null;
+
+
+    /** The message to print. As attribute. */
+    String message;
+    public void setMessage(String msg) {
+        message = msg;
+    }
+
+    /** Should the build fail? Defaults to <i>false</i>. As attribute. */
+    boolean fail = false;
+    public void setFail(boolean b) {
+        fail = b;
+    }
+
+    /** Support for nested text. */
+    public void addText(String text) {
+        message = text;
+    }
+
+
+    /** Do the work. */
+    public void execute() {
+        XProcConfiguration config = new XProcConfiguration("he", false);
+        runtime = new XProcRuntime(config);
+
+	try {
+	    InputSource isource = new InputSource("in.xml");
+	    XMLReader reader = XMLReaderFactory.createXMLReader();
+	    reader.setEntityResolver(runtime.getResolver());
+	    SAXSource source = new SAXSource(reader, isource);
+	    DocumentBuilder builder = runtime.getProcessor().newDocumentBuilder();
+	    builder.setLineNumbering(true);
+	    builder.setDTDValidation(false);
+	    XdmNode doc = builder.build(source);
+	    XdmNode root = S9apiUtils.getDocumentElement(doc);
+	} catch (Exception sae) {
+	    throw new BuildException("Fail requested.");
+	}
+
+	try {
+	    XPipeline pipeline = runtime.load("pipeline.xpl");
+	    XdmNode doc = runtime.parse(new InputSource("in.xml"));
+	    pipeline.writeTo("source", doc);
+	    pipeline.run();
+
+            for (String port : pipeline.getOutputs()) {
+                String uri = null;
+		/*
+                if (cmd.outputs.containsKey(port)) {
+                    uri = cmd.outputs.get(port);
+                } else if (config.outputs.containsKey(port)) {
+                    uri = config.outputs.get(port);
+                }
+
+                if (port.equals(stdio)) {
+                    finest(logger, null, "Copy output from " + port + " to stdout");
+                    uri = null;
+                } else if (uri == null) {
+                    // You didn't bind it, and it isn't going to stdout, so it's going into the bit bucket.
+                    continue;
+                } else {
+                    finest(logger, null, "Copy output from " + port + " to " + uri);
+                }
+		*/
+                Serialization serial = pipeline.getSerialization(port);
+
+                if (serial == null) {
+                    // Use the configuration options
+                    // FIXME: should each of these be considered separately?
+                    // FIXME: should there be command-line options to override these settings?
+                    serial = new Serialization(runtime, pipeline.getNode()); // The node's a hack
+                    for (String name : config.serializationOptions.keySet()) {
+                        String value = config.serializationOptions.get(name);
+
+                        if ("byte-order-mark".equals(name)) serial.setByteOrderMark("true".equals(value));
+                        if ("escape-uri-attributes".equals(name)) serial.setEscapeURIAttributes("true".equals(value));
+                        if ("include-content-type".equals(name)) serial.setIncludeContentType("true".equals(value));
+                        if ("indent".equals(name)) serial.setIndent("true".equals(value));
+                        if ("omit-xml-declaration".equals(name)) serial.setOmitXMLDeclaration("true".equals(value));
+                        if ("undeclare-prefixes".equals(name)) serial.setUndeclarePrefixes("true".equals(value));
+                        if ("method".equals(name)) serial.setMethod(new QName("", value));
+
+                        // FIXME: if ("cdata-section-elements".equals(name)) serial.setCdataSectionElements();
+                        if ("doctype-public".equals(name)) serial.setDoctypePublic(value);
+                        if ("doctype-system".equals(name)) serial.setDoctypeSystem(value);
+                        if ("encoding".equals(name)) serial.setEncoding(value);
+                        if ("media-type".equals(name)) serial.setMediaType(value);
+                        if ("normalization-form".equals(name)) serial.setNormalizationForm(value);
+                        if ("standalone".equals(name)) serial.setStandalone(value);
+                        if ("version".equals(name)) serial.setVersion(value);
+                    }
+                }
+
+                // I wonder if there's a better way...
+                WritableDocument wd = null;
+                if (uri != null) {
+                    URI furi = new URI(uri);
+                    String filename = furi.getPath();
+                    FileOutputStream outfile = new FileOutputStream(filename);
+                    wd = new WritableDocument(runtime,filename,serial,outfile);
+                } else {
+                    wd = new WritableDocument(runtime,uri,serial);
+                }
+
+                ReadablePipe rpipe = pipeline.readFrom(port);
+                while (rpipe.moreDocuments()) {
+                    wd.write(rpipe.read());
+                }
+
+                if (uri!=null) {
+		    wd.close();
+                }
+            }
+	} catch (Exception err) {
+	    throw new BuildException("Pipeline failed: " + err.toString(), err);
+	}
+        // handle attribute 'fail'
+        if (fail) throw new BuildException("Fail requested.");
+
+        // handle attribute 'message' and nested text
+        if (message!=null) log(message);
+
+        // handle nested elements
+        for (Iterator it=messages.iterator(); it.hasNext(); ) {
+            Message msg = (Message)it.next();
+            log(msg.getMsg());
+        }
+    }
+
+
+    /** Store nested 'message's. */
+    Vector messages = new Vector();
+
+    /** Factory method for creating nested 'message's. */
+    public Message createMessage() {
+        Message msg = new Message();
+        messages.add(msg);
+        return msg;
+    }
+
+    /** A nested 'message'. */
+    public class Message {
+        // Bean constructor
+        public Message() {}
+
+        /** Message to print. */
+        String msg;
+        public void setMsg(String msg) { this.msg = msg; }
+        public String getMsg() { return msg; }
+    }
+
+}

--- a/src/com/xmlcalabash/drivers/CalabashTask.java
+++ b/src/com/xmlcalabash/drivers/CalabashTask.java
@@ -624,7 +624,7 @@ public class CalabashTask extends MatchingTask {
 
 	try {
 	    XPipeline pipeline =
-		runtime.load(pipelineResource.getName());
+		runtime.load(pipelineResource.toString());
 
 	    // The unnamed input is matched to one unmatched input
 	    for (String port : pipeline.getInputs()) {

--- a/src/com/xmlcalabash/drivers/CalabashTask.java
+++ b/src/com/xmlcalabash/drivers/CalabashTask.java
@@ -799,16 +799,18 @@ public class CalabashTask extends MatchingTask {
 			for (String port : outputMappers.keySet()) {
 			    FileNameMapper outputMapper = outputMappers.get(port);
 
-			    Union outputResources = new Union();
 			    String[] outputFileNames =
 				outputMapper.mapFileName(resource.getName());
 			    // Mapper may produce zero or more filenames,
 			    // which may or may not be what was wanted but
 			    // only the user will know that.
-			    for (String fileName : outputFileNames) {
-				outputResources.add(new FileResource(baseDir, fileName));
+			    if (outputFileNames != null) {
+				Union outputResources = new Union();
+				for (String fileName : outputFileNames) {
+				    outputResources.add(new FileResource(baseDir, fileName));
+				}
+				useOutputResources.put(port, outputResources);
 			    }
-			    useOutputResources.put(port, outputResources);
 			}
 		    }
 		}
@@ -878,11 +880,13 @@ public class CalabashTask extends MatchingTask {
 			// Mapper may produce zero or more filenames,
 			// which may or may not be what was wanted but
 			// only the user will know that.
-			Union mappedResources = new Union();
-			for (String fileName : inputFileNames) {
-			    mappedResources.add(new FileResource(baseDir, fileName));
+			if (inputFileNames != null) {
+			    Union mappedResources = new Union();
+			    for (String fileName : inputFileNames) {
+				mappedResources.add(new FileResource(baseDir, fileName));
+			    }
+			    useInputResources.put(port, mappedResources);
 			}
-			useInputResources.put(port, mappedResources);
 		    }
 
                     HashMap<String, Union> useOutputResources =
@@ -907,16 +911,18 @@ public class CalabashTask extends MatchingTask {
 		    for (String port : outputMappers.keySet()) {
 			FileNameMapper outputMapper = outputMappers.get(port);
 
-			Union outputResources = new Union();
                         String[] outputFileNames =
 			    outputMapper.mapFileName(resource.getName());
 			// Mapper may produce zero or more filenames,
 			// which may or may not be what was wanted but
 			// only the user will know that.
-			for (String fileName : outputFileNames) {
-			    outputResources.add(new FileResource(baseDir, fileName));
+			if (outputFileNames != null) {
+			    Union outputResources = new Union();
+			    for (String fileName : outputFileNames) {
+				outputResources.add(new FileResource(baseDir, fileName));
+			    }
+			    useOutputResources.put(port, outputResources);
 			}
-			useOutputResources.put(port, outputResources);
 		    }
                     process(config, useInputResources, useOutputResources, usePipelineResource, optionsMap, parametersTable, force);
                 }
@@ -996,16 +1002,19 @@ public class CalabashTask extends MatchingTask {
 		outputsLastModified.add(resource.getLastModified());
 	    }
 	}
-	long oldestOutputLastModified = Collections.min(outputsLastModified);
+	long oldestOutputLastModified =
+	    outputsLastModified.isEmpty() ? 0 : Collections.min(outputsLastModified);
 
 	log("Newest input time: " + newestInputLastModified, Project.MSG_DEBUG);
 	log("Oldest output time: " + oldestOutputLastModified, Project.MSG_DEBUG);
 	log("Pipeline file " + pipelineResource + " time: " + pipelineLastModified, Project.MSG_DEBUG);
 
-	if (!force && newestInputLastModified < oldestOutputLastModified
-	    && pipelineLastModified < oldestOutputLastModified) {
-	    log("Skipping because all outputs are newer than inputs and newer than pipeline", Project.MSG_DEBUG);
-	    return;
+	if (!force) {
+	    if (newestInputLastModified < oldestOutputLastModified &&
+		pipelineLastModified < oldestOutputLastModified) {
+		log("Skipping because all outputs are newer than inputs and newer than pipeline", Project.MSG_DEBUG);
+		return;
+	    }
 	}
 
 	//log("Processing " + in + " to " + out, Project.MSG_INFO);

--- a/test/build-antunit.xml
+++ b/test/build-antunit.xml
@@ -162,36 +162,44 @@
     </calabash>
   </target>
 
-  <target name="testBinding2" description="Use with 'includes' and 'basedir' values.">
-    <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
-      <sysproperty key="com.xmlcalabash.phonehome" value="false" />
-      <namespace prefix="hi" />
-    </calabash>
+  <target name="testBinding2" description="Namespace prefix but no URI">
+    <au:expectfailure expectedmessage="&lt;namespace> URI cannot be null">
+      <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+	<sysproperty key="com.xmlcalabash.phonehome" value="false" />
+	<namespace prefix="hi" />
+      </calabash>
+    </au:expectfailure>
   </target>
 
   <target name="testBinding3" description="Use with 'includes' and 'basedir' values.">
-    <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
-      <sysproperty key="com.xmlcalabash.phonehome" value="false" />
-      <namespace uri="there" />
-    </calabash>
+    <au:expectfailure expectedmessage="&lt;namespace> prefix cannot be null">
+      <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+	<sysproperty key="com.xmlcalabash.phonehome" value="false" />
+	<namespace uri="there" />
+      </calabash>
+    </au:expectfailure>
   </target>
 
-  <target name="testBinding4" description="Use with 'includes' and 'basedir' values.">
-    <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
-      <sysproperty key="com.xmlcalabash.phonehome" value="false" />
-      <namespace />
-    </calabash>
+  <target name="testBinding4" description="No prefix, no URI.">
+    <au:expectfailure expectedmessage="cannot be null">
+      <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+	<sysproperty key="com.xmlcalabash.phonehome" value="false" />
+	<namespace />
+      </calabash>
+    </au:expectfailure>
   </target>
 
-  <target name="testBinding5" description="Use with 'includes' and 'basedir' values.">
-    <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
-      <sysproperty key="com.xmlcalabash.phonehome" value="false" />
-      <namespace prefix="hi" uri="there" />
-      <namespace prefix="hi" uri="not there" />
-    </calabash>
+  <target name="testBinding5" description="Duplicated namespace prefix.">
+    <au:expectfailure expectedmessage="Duplicated &lt;namespace> prefix">
+      <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+	<sysproperty key="com.xmlcalabash.phonehome" value="false" />
+	<namespace prefix="hi" uri="there" />
+	<namespace prefix="hi" uri="not there" />
+      </calabash>
+    </au:expectfailure>
   </target>
 
-  <target name="testParameter1" description="Use with 'includes' and 'basedir' values.">
+  <target name="testParameter1" description="Bound prefix.">
     <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
       <sysproperty key="com.xmlcalabash.phonehome" value="false" />
       <namespace prefix="hi" uri="there" />
@@ -200,37 +208,46 @@
   </target>
 
   <target name="testParameter2" description="Use with 'includes' and 'basedir' values.">
-    <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
-      <sysproperty key="com.xmlcalabash.phonehome" value="false" />
-      <namespace prefix="hi" uri="there" />
-      <parameter name="not:there" value="a value" />
-    </calabash>
+    <au:expectfailure expectedmessage="Unbound prefix">
+      <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+	<sysproperty key="com.xmlcalabash.phonehome" value="false" />
+	<namespace prefix="hi" uri="there" />
+	<parameter name="not:there" value="a value" />
+      </calabash>
+    </au:expectfailure>
   </target>
 
-  <target name="testParameter3" description="Use with 'includes' and 'basedir' values.">
-    <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
-      <sysproperty key="com.xmlcalabash.phonehome" value="false" />
-      <namespace prefix="hi" uri="there" />
-      <parameter name="hi:there" value="a value" />
-      <parameter name="hi:there" value="another value" />
-    </calabash>
+  <target name="testParameter3" description="Duplicated parameter QName.">
+    <au:expectfailure expectedmessage="Duplicated parameter QName">
+      <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+	<sysproperty key="com.xmlcalabash.phonehome" value="false" />
+	<namespace prefix="hi" uri="there" />
+	<parameter name="hi:there" value="a value" />
+	<parameter name="hi:there" value="another value" />
+      </calabash>
+    </au:expectfailure>
   </target>
 
-  <target name="testParameter4" description="Use with 'includes' and 'basedir' values.">
-    <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
-      <sysproperty key="com.xmlcalabash.phonehome" value="false" />
-      <namespace prefix="hi" uri="there" />
-      <namespace prefix="not" uri="there" />
-      <parameter name="hi:there" value="a value" />
-      <parameter name="not:there" value="another value" />
-    </calabash>
+  <target name="testParameter4" description="Duplicated parameter QName: same URI, different prefixes.">
+    <au:expectfailure expectedmessage="Duplicated parameter QName">
+      <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+	<sysproperty key="com.xmlcalabash.phonehome" value="false" />
+	<namespace prefix="hi" uri="there" />
+	<namespace prefix="not" uri="there" />
+	<parameter name="hi:there" value="a value" />
+	<parameter name="not:there" value="another value" />
+      </calabash>
+    </au:expectfailure>
   </target>
 
-  <target name="testParameter5" description="'p' prefix should be bound automatically but is an error to use it for parameters.">
-    <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
-      <sysproperty key="com.xmlcalabash.phonehome" value="false" />
-      <parameter name="p:there" value="in your morning" />
-    </calabash>
+  <target name="testParameter5"
+	  description="'p' prefix should be bound automatically but is an error to use it for parameters.  Should fail with 'XD0031'.">
+    <au:expectfailure expectedmessage="XD0031">
+      <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+	<sysproperty key="com.xmlcalabash.phonehome" value="false" />
+	<parameter name="p:there" value="in your morning" />
+      </calabash>
+    </au:expectfailure>
   </target>
 
   <target name="testParameter6" description="Empty parameter name.">
@@ -247,13 +264,34 @@
     </calabash>
   </target>
 
-  <target name="testParameter8" description="No-namespace parameter name.">
+  <target name="testParameter8" description="Clack notation in parameter name.">
     <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
       <sysproperty key="com.xmlcalabash.phonehome" value="false" />
-      <namespace prefix="hi" uri="hi" />
+      <namespace prefix="hi" uri="low" />
       <parameter name="{hi}there" value="a value" />
       <parameter name="hi:there" value="a value" />
     </calabash>
+  </target>
+
+  <target name="testParameter9" description="Clack notation in duplicate parameter names.">
+    <au:expectfailure expectedmessage="Duplicated parameter QName">
+      <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+	<sysproperty key="com.xmlcalabash.phonehome" value="false" />
+	<parameter name="{hi}there" value="a value" />
+	<parameter name="{hi}there" value="another value" />
+      </calabash>
+    </au:expectfailure>
+  </target>
+
+  <target name="testParameter10" description="Duplicate QName in bound and Clack notation parameter names.">
+    <au:expectfailure expectedmessage="Duplicated parameter QName">
+      <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+	<sysproperty key="com.xmlcalabash.phonehome" value="false" />
+	<namespace prefix="hi" uri="low" />
+	<parameter name="{low}there" value="a value" />
+	<parameter name="hi:there" value="a value" />
+      </calabash>
+    </au:expectfailure>
   </target>
 
   <target name="testOption1" description="Valid no-namespace option.">

--- a/test/build-antunit.xml
+++ b/test/build-antunit.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <project name="CalabashTask-antunit"
 	 basedir="."
+	 default="antunit"
 	 xmlns:au="antlib:org.apache.ant.antunit">
 
   <dirname property="test.basedir" file="${ant.file.CalabashTask-antunit}"/>
@@ -64,6 +65,24 @@
     </calabash>
   </target>
 
+  <target name="testNestedPipeline" description="Use with nested 'pipeline'">
+    <calabash in="in.xml" out="out7.xml">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
+      <pipeline>
+	<file file="pipeline.xpl" />
+      </pipeline>
+    </calabash>
+  </target>
+
+  <target name="TestMultiport1" description="Use with multiple input ports.">
+    <calabash in="doc.xml" out="out8.xml" pipeline="compare-001.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
+      <input port="alternate">
+	<file file="doc.xml" />
+      </input>
+    </calabash>
+  </target>
+
   <target name="testOutport3" description="Use with real 'outport' value.">
     <calabash in="in.xml" outport="result" pipeline="pipeline.xpl">
       <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
@@ -82,21 +101,48 @@
     </calabash>
   </target>
 
-  <target name="testNestedPipeline" description="Use with nested 'pipeline'">
-    <calabash in="in.xml" out="out7.xml">
+  <target name="testNestedInput1" description="Use with nested input port.">
+    <calabash out="out11.xml" pipeline="pipeline.xpl">
       <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
-      <pipeline>
-	<file file="pipeline.xpl" />
-      </pipeline>
+      <input port="source">
+	<file file="in.xml" />
+      </input>
     </calabash>
   </target>
 
-  <target name="TestMultiport1" description="Use with multiple input ports.">
-    <calabash in="doc.xml" out="out8.xml" pipeline="compare-001.xpl">
+  <target name="testNestedInput2" description="Use with nested input port.">
+    <calabash out="out12.xml" pipeline="pipeline.xpl">
       <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
+      <input>
+	<file file="in.xml" />
+      </input>
+    </calabash>
+  </target>
+
+  <target name="testMultiport2" description="Use with multiple input ports.">
+    <calabash out="out13.xml" pipeline="compare-001.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
+      <input port="source">
+	<file file="doc.xml" />
+      </input>
       <input port="alternate">
 	<file file="doc.xml" />
       </input>
+    </calabash>
+  </target>
+
+  <target name="testIncludes1" description="Use with 'includes' value.">
+    <calabash includes="in.xml" outport="result" pipeline="pipeline.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
+      <output>
+	<file file="out14.xml" />
+      </output>
+    </calabash>
+  </target>
+
+  <target name="testIncludes2" description="Use with 'includes' value.">
+    <calabash includes="in*.xml" pipeline="pipeline.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
     </calabash>
   </target>
 

--- a/test/build-antunit.xml
+++ b/test/build-antunit.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<project name="CalabashTask-antunit"
+	 basedir="."
+	 xmlns:au="antlib:org.apache.ant.antunit">
+
+  <dirname property="test.basedir" file="${ant.file.CalabashTask-antunit}"/>
+
+  <property name="antunit.home" value="/usr/local/src/apache-ant-antunit-1.2"/>
+
+  <taskdef 
+      uri="antlib:org.apache.ant.antunit"
+      resource="org/apache/ant/antunit/antlib.xml">
+    <classpath>
+      <pathelement location="${antunit.home}/ant-antunit-1.2.jar"/>
+    </classpath>
+  </taskdef>
+
+  <taskdef name="calabash"
+	   classname="com.xmlcalabash.drivers.CalabashTask"
+	   classpath="${test.basedir}/../calabash.jar"/>
+
+  <target name="antunit">
+    <au:antunit>
+      <file file="build-antunit.xml"/>
+      <au:plainlistener/>
+    </au:antunit>
+  </target>
+
+  <target name="testBasic" description="Use without 'in', 'out', and 'pipeline'.">
+    <calabash in="in.xml" out="out1.xml" pipeline="pipeline.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
+    </calabash>
+  </target>
+
+  <target name="testIn2" description="Use with different input.">
+    <calabash in="in2.xml" out="out2.xml" pipeline="pipeline.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
+    </calabash>
+  </target>
+
+  <target name="testInport" description="Use with bogus 'inport'.">
+    <au:expectfailure expectedmessage="0 documents appear on the 'source' port.">
+      <calabash in="in.xml" out="out3.xml" inport="bogus" pipeline="pipeline.xpl">
+	<sysproperty key="com.xmlcalabash.phonehome" value="false"/>
+      </calabash>
+    </au:expectfailure>
+  </target>
+
+  <target name="testInport2" description="Use with real 'inport' value.">
+    <calabash in="in.xml" inport="source" out="out4.xml" pipeline="pipeline.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
+    </calabash>
+  </target>
+
+  <target name="testOutport" description="Use with bogus 'outport'.">
+    <calabash in="in.xml" out="out5.xml" outport="bogus" pipeline="pipeline.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
+    </calabash>
+  </target>
+
+  <target name="testOutport2" description="Use with real 'outport' value.">
+    <calabash in="in.xml" out="out6.xml" outport="result" pipeline="pipeline.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
+    </calabash>
+  </target>
+
+  <target name="testOutport3" description="Use with real 'outport' value.">
+    <calabash in="in.xml" outport="result" pipeline="pipeline.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
+      <output>
+	<file file="out9.xml" />
+      </output>
+    </calabash>
+  </target>
+
+  <target name="testOutport4" description="Use with real 'outport' value.">
+    <calabash in="in.xml" pipeline="pipeline.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
+      <output port="result">
+	<file file="out10.xml" />
+      </output>
+    </calabash>
+  </target>
+
+  <target name="testNestedPipeline" description="Use with nested 'pipeline'">
+    <calabash in="in.xml" out="out7.xml">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
+      <pipeline>
+	<file file="pipeline.xpl" />
+      </pipeline>
+    </calabash>
+  </target>
+
+  <target name="TestMultiport1" description="Use with multiple input ports.">
+    <calabash in="doc.xml" out="out8.xml" pipeline="compare-001.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
+      <input port="alternate">
+	<file file="doc.xml" />
+      </input>
+    </calabash>
+  </target>
+
+</project>

--- a/test/build-antunit.xml
+++ b/test/build-antunit.xml
@@ -27,6 +27,8 @@
     </au:antunit>
   </target>
 
+  <mkdir dir="out" />
+
   <target name="testBasic" description="Use without 'in', 'out', and 'pipeline'.">
     <calabash in="in.xml" out="out1.xml" pipeline="pipeline.xpl">
       <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
@@ -141,8 +143,114 @@
   </target>
 
   <target name="testIncludes2" description="Use with 'includes' value.">
-    <calabash includes="in*.xml" pipeline="pipeline.xpl">
+    <calabash includes="in*.xml" destdir="out" pipeline="pipeline.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false" />
+    </calabash>
+  </target>
+
+
+  <target name="testIncludes3" description="Use with 'includes' and 'basedir' values.">
+    <calabash includes="in*.xml" basedir="in" destdir="out" pipeline="pipeline.xpl">
       <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
+    </calabash>
+  </target>
+
+  <target name="testBinding1" description="Use with 'includes' and 'basedir' values.">
+    <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false" />
+      <namespace prefix="hi" uri="there" />
+    </calabash>
+  </target>
+
+  <target name="testBinding2" description="Use with 'includes' and 'basedir' values.">
+    <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false" />
+      <namespace prefix="hi" />
+    </calabash>
+  </target>
+
+  <target name="testBinding3" description="Use with 'includes' and 'basedir' values.">
+    <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false" />
+      <namespace uri="there" />
+    </calabash>
+  </target>
+
+  <target name="testBinding4" description="Use with 'includes' and 'basedir' values.">
+    <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false" />
+      <namespace />
+    </calabash>
+  </target>
+
+  <target name="testBinding5" description="Use with 'includes' and 'basedir' values.">
+    <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false" />
+      <namespace prefix="hi" uri="there" />
+      <namespace prefix="hi" uri="not there" />
+    </calabash>
+  </target>
+
+  <target name="testParameter1" description="Use with 'includes' and 'basedir' values.">
+    <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false" />
+      <namespace prefix="hi" uri="there" />
+      <parameter name="hi:there" value="a value" />
+    </calabash>
+  </target>
+
+  <target name="testParameter2" description="Use with 'includes' and 'basedir' values.">
+    <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false" />
+      <namespace prefix="hi" uri="there" />
+      <parameter name="not:there" value="a value" />
+    </calabash>
+  </target>
+
+  <target name="testParameter3" description="Use with 'includes' and 'basedir' values.">
+    <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false" />
+      <namespace prefix="hi" uri="there" />
+      <parameter name="hi:there" value="a value" />
+      <parameter name="hi:there" value="another value" />
+    </calabash>
+  </target>
+
+  <target name="testParameter4" description="Use with 'includes' and 'basedir' values.">
+    <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false" />
+      <namespace prefix="hi" uri="there" />
+      <namespace prefix="not" uri="there" />
+      <parameter name="hi:there" value="a value" />
+      <parameter name="not:there" value="another value" />
+    </calabash>
+  </target>
+
+  <target name="testParameter5" description="'p' prefix should be bound automatically.">
+    <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false" />
+      <parameter name="p:there" value="in your morning" />
+    </calabash>
+  </target>
+
+  <target name="testParameter6" description="Empty parameter name.">
+    <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false" />
+      <parameter name="" value="a value" />
+    </calabash>
+  </target>
+
+  <target name="testParameter7" description="No-namespace parameter name.">
+    <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false" />
+      <parameter name="no-namespace" value="a value" />
+    </calabash>
+  </target>
+
+  <target name="testOption1" description="Valid no-namespace option.">
+    <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false" />
+      <option name="no-namespace" value="a value" />
     </calabash>
   </target>
 

--- a/test/build-antunit.xml
+++ b/test/build-antunit.xml
@@ -30,45 +30,86 @@
   <mkdir dir="out" />
 
   <target name="testBasic" description="Use without 'in', 'out', and 'pipeline'.">
-    <calabash in="in.xml" out="out1.xml" pipeline="pipeline.xpl">
+    <calabash in="in/in.xml" out="out/out.xml" pipeline="pipeline.xpl" force="true">
       <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
     </calabash>
   </target>
 
   <target name="testIn2" description="Use with different input.">
-    <calabash in="in2.xml" out="out2.xml" pipeline="pipeline.xpl">
+    <calabash in="in/in2.xml" out="out/out.xml" pipeline="pipeline.xpl" force="true">
       <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
     </calabash>
   </target>
 
   <target name="testInport" description="Use with bogus 'inport'.">
+    <touch file="in/in.xml" />
     <au:expectfailure expectedmessage="0 documents appear on the 'source' port.">
-      <calabash in="in.xml" out="out3.xml" inport="bogus" pipeline="pipeline.xpl">
+      <calabash in="in/in.xml" out="out/out.xml" inport="bogus" pipeline="pipeline.xpl">
 	<sysproperty key="com.xmlcalabash.phonehome" value="false"/>
       </calabash>
     </au:expectfailure>
   </target>
 
   <target name="testInport2" description="Use with real 'inport' value.">
-    <calabash in="in.xml" inport="source" out="out4.xml" pipeline="pipeline.xpl">
+    <calabash in="in/in.xml" inport="source" out="out/out.xml" pipeline="pipeline.xpl" force="true">
       <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
     </calabash>
   </target>
 
+  <target name="testInport3" description="No input documents.">
+    <au:expectfailure expectedmessage="0 documents appear on the 'source' port.">
+      <calabash inport="source" out="out/out.xml" pipeline="pipeline.xpl" force="true">
+	<sysproperty key="com.xmlcalabash.phonehome" value="false"/>
+	<input port="source" />
+      </calabash>
+    </au:expectfailure>
+  </target>
+
+  <target name="testInport4" description="No input documents.">
+    <au:expectfailure expectedmessage="Both mapper and fileset on input port">
+      <calabash in="in/doc.xml"
+		inport="source"
+		out="out/out.xml"
+		pipeline="xpl/compare-001.xpl"
+		force="true">
+	<sysproperty key="com.xmlcalabash.phonehome" value="false"/>
+	<input port="alternate">
+	  <file file="in/doc.xml" />
+	  <identitymapper />
+	</input>
+      </calabash>
+    </au:expectfailure>
+  </target>
+
+  <target name="testInport5" description="Mapper on secondary input port.">
+    <calabash includes="doc.xml"
+	      basedir="in"
+	      inport="source"
+	      destdir="out"
+	      extension=".inport5.xml"
+	      pipeline="xpl/compare-001.xpl"
+	      force="true">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
+      <input port="alternate">
+	<globmapper from="*.xml" to="*-alt.xml" />
+      </input>
+    </calabash>
+  </target>
+
   <target name="testOutport" description="Use with bogus 'outport'.">
-    <calabash in="in.xml" out="out5.xml" outport="bogus" pipeline="pipeline.xpl">
+    <calabash in="in/in.xml" out="out/out.xml" outport="bogus" pipeline="pipeline.xpl" force="true">
       <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
     </calabash>
   </target>
 
   <target name="testOutport2" description="Use with real 'outport' value.">
-    <calabash in="in.xml" out="out6.xml" outport="result" pipeline="pipeline.xpl">
+    <calabash in="in/in.xml" out="out/out.xml" outport="result" pipeline="pipeline.xpl" force="true">
       <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
     </calabash>
   </target>
 
   <target name="testNestedPipeline" description="Use with nested 'pipeline'">
-    <calabash in="in.xml" out="out7.xml">
+    <calabash in="in/in.xml" out="out/out.xml" force="true">
       <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
       <pipeline>
 	<file file="pipeline.xpl" />
@@ -77,86 +118,162 @@
   </target>
 
   <target name="TestMultiport1" description="Use with multiple input ports.">
-    <calabash in="doc.xml" out="out8.xml" pipeline="compare-001.xpl">
+    <calabash in="in/doc.xml" out="out/out.xml" pipeline="xpl/compare-001.xpl" force="true">
       <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
       <input port="alternate">
-	<file file="doc.xml" />
+	<file file="in/doc.xml" />
       </input>
     </calabash>
   </target>
 
   <target name="testOutport3" description="Use with real 'outport' value.">
-    <calabash in="in.xml" outport="result" pipeline="pipeline.xpl">
+    <calabash in="in/in.xml" outport="result" pipeline="pipeline.xpl" force="true">
       <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
       <output>
-	<file file="out9.xml" />
+	<file file="out/out.xml" />
       </output>
     </calabash>
   </target>
 
   <target name="testOutport4" description="Use with real 'outport' value.">
-    <calabash in="in.xml" pipeline="pipeline.xpl">
+    <calabash in="in/in.xml" pipeline="pipeline.xpl" force="true">
       <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
       <output port="result">
-	<file file="out10.xml" />
+	<file file="out/out.xml" />
       </output>
     </calabash>
   </target>
 
+  <target name="testOutputMapper1" description=".">
+    <delete>
+      <fileset dir="out" includes="group-003*" />
+    </delete>
+    <calabash includes="group-003_input1.xml"
+	      basedir="in"
+	      destdir="out"
+	      pipeline="xpl/group-003.xpl"
+	      force="true">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
+      <output port="result">
+	<globmapper from="*_input1.xml" to="../out/*_result.xml" />
+      </output>
+      <output port="result2">
+	<globmapper from="*_input1.xml" to="../out/*_result2.xml" />
+      </output>
+    </calabash>
+    <au:assertResourceContains
+	resource="out/group-003_result.xml"
+	value="&lt;foo" />
+    <au:assertResourceContains
+	resource="out/group-003_result2.xml"
+	value="Some Title" />
+  </target>
+
+  <target name="testOutputMapper2" description=".">
+    <delete>
+      <fileset dir="out" includes="group-003*" />
+    </delete>
+    <calabash includes="group-003_input1.xml"
+	      basedir="in"
+	      destdir="out"
+	      pipeline="xpl/group-003.xpl"
+	      force="true">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
+      <output>
+	<globmapper from="*_input1.xml" to="../out/*_result.xml" />
+      </output>
+      <output port="result2">
+	<globmapper from="*_input1.xml" to="../out/*_result2.xml" />
+      </output>
+    </calabash>
+    <au:assertResourceContains
+	resource="out/group-003_result.xml"
+	value="&lt;foo" />
+    <au:assertResourceContains
+	resource="out/group-003_result2.xml"
+	value="Some Title" />
+  </target>
+
   <target name="testNestedInput1" description="Use with nested input port.">
-    <calabash out="out11.xml" pipeline="pipeline.xpl">
+    <calabash out="out/out.xml" pipeline="pipeline.xpl" force="true">
       <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
       <input port="source">
-	<file file="in.xml" />
+	<file file="in/in.xml" />
       </input>
     </calabash>
   </target>
 
   <target name="testNestedInput2" description="Use with nested input port.">
-    <calabash out="out12.xml" pipeline="pipeline.xpl">
+    <calabash out="out/out.xml" pipeline="pipeline.xpl" force="true">
       <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
       <input>
-	<file file="in.xml" />
+	<file file="in/in.xml" />
       </input>
     </calabash>
   </target>
 
   <target name="testMultiport2" description="Use with multiple input ports.">
-    <calabash out="out13.xml" pipeline="compare-001.xpl">
+    <calabash out="out/out.xml" pipeline="xpl/compare-001.xpl" force="true">
       <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
       <input port="source">
-	<file file="doc.xml" />
+	<file file="in/doc.xml" />
       </input>
       <input port="alternate">
-	<file file="doc.xml" />
+	<file file="in/doc.xml" />
       </input>
     </calabash>
   </target>
 
   <target name="testIncludes1" description="Use with 'includes' value.">
-    <calabash includes="in.xml" outport="result" pipeline="pipeline.xpl">
+    <calabash includes="in/in.xml" outport="result" pipeline="pipeline.xpl" force="true">
       <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
       <output>
-	<file file="out14.xml" />
+	<file file="out/out.xml" />
       </output>
     </calabash>
   </target>
 
   <target name="testIncludes2" description="Use with 'includes' value.">
-    <calabash includes="in*.xml" destdir="out" pipeline="pipeline.xpl">
+    <calabash includes="in*.xml" destdir="out" pipeline="pipeline.xpl" force="true">
       <sysproperty key="com.xmlcalabash.phonehome" value="false" />
     </calabash>
   </target>
 
 
   <target name="testIncludes3" description="Use with 'includes' and 'basedir' values.">
-    <calabash includes="in*.xml" basedir="in" destdir="out" pipeline="pipeline.xpl">
+    <calabash includes="in*.xml"
+	      basedir="in"
+	      destdir="out"
+	      pipeline="pipeline.xpl"
+	      force="true">
       <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
     </calabash>
   </target>
 
-  <target name="testBinding1" description="Use with 'includes' and 'basedir' values.">
-    <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+  <target name="testIncludes4" description="Use 'extension' with 'includes' and 'basedir' values.">
+    <calabash includes="in*.xml"
+	      basedir="in"
+	      destdir="out"
+	      extension=".extension.xml"
+	      pipeline="pipeline.xpl"
+	      force="true">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
+    </calabash>
+  </target>
+
+  <target name="testIncludes5" description="Use a globmapper with 'includes' and 'basedir' values.">
+    <calabash includes="in*.xml"
+	      basedir="in"
+	      destdir="out"
+	      pipeline="pipeline.xpl"
+	      force="true">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
+      <globmapper from="*.xml" to="*.glob.xml" />
+    </calabash>
+  </target>
+
+  <target name="testBinding1" description="Namespace but no option or param.">
+    <calabash in="in/in.xml" out="out/out.xml" pipeline="pipeline.xpl" force="true">
       <sysproperty key="com.xmlcalabash.phonehome" value="false" />
       <namespace prefix="hi" uri="there" />
     </calabash>
@@ -164,7 +281,7 @@
 
   <target name="testBinding2" description="Namespace prefix but no URI">
     <au:expectfailure expectedmessage="&lt;namespace> URI cannot be null">
-      <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+      <calabash in="in/in.xml" out="out/out.xml" pipeline="pipeline.xpl" force="true">
 	<sysproperty key="com.xmlcalabash.phonehome" value="false" />
 	<namespace prefix="hi" />
       </calabash>
@@ -173,7 +290,7 @@
 
   <target name="testBinding3" description="Use with 'includes' and 'basedir' values.">
     <au:expectfailure expectedmessage="&lt;namespace> prefix cannot be null">
-      <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+      <calabash in="in/in.xml" out="out/out.xml" pipeline="pipeline.xpl" force="true">
 	<sysproperty key="com.xmlcalabash.phonehome" value="false" />
 	<namespace uri="there" />
       </calabash>
@@ -182,7 +299,7 @@
 
   <target name="testBinding4" description="No prefix, no URI.">
     <au:expectfailure expectedmessage="cannot be null">
-      <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+      <calabash in="in/in.xml" out="out/out.xml" pipeline="pipeline.xpl" force="true">
 	<sysproperty key="com.xmlcalabash.phonehome" value="false" />
 	<namespace />
       </calabash>
@@ -191,7 +308,7 @@
 
   <target name="testBinding5" description="Duplicated namespace prefix.">
     <au:expectfailure expectedmessage="Duplicated &lt;namespace> prefix">
-      <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+      <calabash in="in/in.xml" out="out/out.xml" pipeline="pipeline.xpl" force="true">
 	<sysproperty key="com.xmlcalabash.phonehome" value="false" />
 	<namespace prefix="hi" uri="there" />
 	<namespace prefix="hi" uri="not there" />
@@ -200,7 +317,7 @@
   </target>
 
   <target name="testParameter1" description="Bound prefix.">
-    <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+    <calabash in="in/in.xml" out="out/out.xml" pipeline="pipeline.xpl" force="true">
       <sysproperty key="com.xmlcalabash.phonehome" value="false" />
       <namespace prefix="hi" uri="there" />
       <parameter name="hi:there" value="a value" />
@@ -209,7 +326,7 @@
 
   <target name="testParameter2" description="Use with 'includes' and 'basedir' values.">
     <au:expectfailure expectedmessage="Unbound prefix">
-      <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+      <calabash in="in/in.xml" out="out/out.xml" pipeline="pipeline.xpl" force="true">
 	<sysproperty key="com.xmlcalabash.phonehome" value="false" />
 	<namespace prefix="hi" uri="there" />
 	<parameter name="not:there" value="a value" />
@@ -219,7 +336,7 @@
 
   <target name="testParameter3" description="Duplicated parameter QName.">
     <au:expectfailure expectedmessage="Duplicated parameter QName">
-      <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+      <calabash in="in/in.xml" out="out/out.xml" pipeline="pipeline.xpl" force="true">
 	<sysproperty key="com.xmlcalabash.phonehome" value="false" />
 	<namespace prefix="hi" uri="there" />
 	<parameter name="hi:there" value="a value" />
@@ -230,7 +347,7 @@
 
   <target name="testParameter4" description="Duplicated parameter QName: same URI, different prefixes.">
     <au:expectfailure expectedmessage="Duplicated parameter QName">
-      <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+      <calabash in="in/in.xml" out="out/out.xml" pipeline="pipeline.xpl" force="true">
 	<sysproperty key="com.xmlcalabash.phonehome" value="false" />
 	<namespace prefix="hi" uri="there" />
 	<namespace prefix="not" uri="there" />
@@ -242,8 +359,9 @@
 
   <target name="testParameter5"
 	  description="'p' prefix should be bound automatically but is an error to use it for parameters.  Should fail with 'XD0031'.">
+    <touch file="in/in.xml" />
     <au:expectfailure expectedmessage="XD0031">
-      <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+      <calabash in="in/in.xml" out="out/out.xml" pipeline="pipeline.xpl" force="true">
 	<sysproperty key="com.xmlcalabash.phonehome" value="false" />
 	<parameter name="p:there" value="in your morning" />
       </calabash>
@@ -251,21 +369,21 @@
   </target>
 
   <target name="testParameter6" description="Empty parameter name.">
-    <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+    <calabash in="in/in.xml" out="out/out.xml" pipeline="pipeline.xpl" force="true">
       <sysproperty key="com.xmlcalabash.phonehome" value="false" />
       <parameter name="" value="a value" />
     </calabash>
   </target>
 
   <target name="testParameter7" description="No-namespace parameter name.">
-    <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+    <calabash in="in/in.xml" out="out/out.xml" pipeline="pipeline.xpl" force="true">
       <sysproperty key="com.xmlcalabash.phonehome" value="false" />
       <parameter name="no-namespace" value="a value" />
     </calabash>
   </target>
 
   <target name="testParameter8" description="Clack notation in parameter name.">
-    <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+    <calabash in="in/in.xml" out="out/out.xml" pipeline="pipeline.xpl" force="true">
       <sysproperty key="com.xmlcalabash.phonehome" value="false" />
       <namespace prefix="hi" uri="low" />
       <parameter name="{hi}there" value="a value" />
@@ -275,7 +393,7 @@
 
   <target name="testParameter9" description="Clack notation in duplicate parameter names.">
     <au:expectfailure expectedmessage="Duplicated parameter QName">
-      <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+      <calabash in="in/in.xml" out="out/out.xml" pipeline="pipeline.xpl" force="true">
 	<sysproperty key="com.xmlcalabash.phonehome" value="false" />
 	<parameter name="{hi}there" value="a value" />
 	<parameter name="{hi}there" value="another value" />
@@ -285,7 +403,7 @@
 
   <target name="testParameter10" description="Duplicate QName in bound and Clack notation parameter names.">
     <au:expectfailure expectedmessage="Duplicated parameter QName">
-      <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+      <calabash in="in/in.xml" out="out/out.xml" pipeline="pipeline.xpl" force="true">
 	<sysproperty key="com.xmlcalabash.phonehome" value="false" />
 	<namespace prefix="hi" uri="low" />
 	<parameter name="{low}there" value="a value" />
@@ -295,14 +413,14 @@
   </target>
 
   <target name="testOption1" description="Valid no-namespace option.">
-    <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+    <calabash in="in/in.xml" out="out/out.xml" pipeline="pipeline.xpl" force="true">
       <sysproperty key="com.xmlcalabash.phonehome" value="false" />
       <option name="no-namespace" value="a value" />
     </calabash>
   </target>
 
   <target name="testOption2" description="'p' prefix should be bound automatically.">
-    <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+    <calabash in="in/in.xml" out="out/out.xml" pipeline="pipeline.xpl" force="true">
       <sysproperty key="com.xmlcalabash.phonehome" value="false" />
       <option name="p:there" value="in your night" />
     </calabash>

--- a/test/build-antunit.xml
+++ b/test/build-antunit.xml
@@ -226,7 +226,7 @@
     </calabash>
   </target>
 
-  <target name="testParameter5" description="'p' prefix should be bound automatically.">
+  <target name="testParameter5" description="'p' prefix should be bound automatically but is an error to use it for parameters.">
     <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
       <sysproperty key="com.xmlcalabash.phonehome" value="false" />
       <parameter name="p:there" value="in your morning" />
@@ -247,10 +247,26 @@
     </calabash>
   </target>
 
+  <target name="testParameter8" description="No-namespace parameter name.">
+    <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false" />
+      <namespace prefix="hi" uri="hi" />
+      <parameter name="{hi}there" value="a value" />
+      <parameter name="hi:there" value="a value" />
+    </calabash>
+  </target>
+
   <target name="testOption1" description="Valid no-namespace option.">
     <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
       <sysproperty key="com.xmlcalabash.phonehome" value="false" />
       <option name="no-namespace" value="a value" />
+    </calabash>
+  </target>
+
+  <target name="testOption2" description="'p' prefix should be bound automatically.">
+    <calabash in="in.xml" out="out.xml" pipeline="pipeline.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false" />
+      <option name="p:there" value="in your night" />
     </calabash>
   </target>
 

--- a/test/build-task-test.xml
+++ b/test/build-task-test.xml
@@ -33,33 +33,42 @@
   </target>
 
 
-  <target name="use.without" description="Use without any" depends="use.init">
-    <calabash/>
+  <target name="use.basic" description="Use without 'in', 'out', and 'pipeline'." depends="use.init">
+    <calabash in="in.xml" out="out1.xml" pipeline="pipeline.xpl"/>
   </target>
 
-  <target name="use.message" description="Use with attribute 'message'" depends="use.init">
-    <calabash message="attribute-text"/>
+  <target name="use.in2" description="Use with different input." depends="use.init">
+    <calabash in="in2.xml" out="out2.xml" pipeline="pipeline.xpl" />
   </target>
 
-  <target name="use.fail" description="Use with attribute 'fail'" depends="use.init">
-    <calabash fail="true"/>
+  <target name="use.inport" description="Use with bogus 'inport'." depends="use.init">
+    <calabash in="in.xml" out="out3.xml" inport="bogus" pipeline="pipeline.xpl" />
   </target>
 
-  <target name="use.nestedText" description="Use with nested text" depends="use.init">
-    <calabash>nested-text</calabash>
+  <target name="use.inport2" description="Use with real 'inport' value." depends="use.init">
+    <calabash in="in.xml" inport="source" out="out4.xml" pipeline="pipeline.xpl" />
   </target>
 
-  <target name="use.nestedElement" description="Use with nested 'message'" depends="use.init">
-    <calabash>
-      <message msg="Nested Element 1"/>
-      <message msg="Nested Element 2"/>
+  <target name="use.outport" description="Use with bogus 'outport'." depends="use.init">
+    <calabash in="in.xml" out="out5.xml" outport="bogus" pipeline="pipeline.xpl" />
+  </target>
+
+  <target name="use.outport2" description="Use with real 'outport' value." depends="use.init">
+    <calabash in="in.xml" out="out6.xml" outport="result" pipeline="pipeline.xpl" />
+  </target>
+
+  <target name="use.nestedPipeline" description="Use with nested 'pipeline'" depends="use.init">
+    <calabash in="in.xml" out="out7.xml">
+      <pipeline>
+	<file file="pipeline.xpl" />
+      </pipeline>
     </calabash>
   </target>
 
 
   <target name="use"
-	  description="Try all (w/out use.fail)"
-	  depends="use.without,use.message,use.nestedText,use.nestedElement"
+	  description="Try all"
+	  depends="use.basic,use.in2,use.inport2,use.outport,use.outport2,use.nestedPipeline"
 	  />
 
 

--- a/test/build-task-test.xml
+++ b/test/build-task-test.xml
@@ -34,41 +34,63 @@
 
 
   <target name="use.basic" description="Use without 'in', 'out', and 'pipeline'." depends="use.init">
-    <calabash in="in.xml" out="out1.xml" pipeline="pipeline.xpl"/>
+    <calabash in="in.xml" out="out1.xml" pipeline="pipeline.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
+    </calabash>
   </target>
 
   <target name="use.in2" description="Use with different input." depends="use.init">
-    <calabash in="in2.xml" out="out2.xml" pipeline="pipeline.xpl" />
+    <calabash in="in2.xml" out="out2.xml" pipeline="pipeline.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
+    </calabash>
   </target>
 
   <target name="use.inport" description="Use with bogus 'inport'." depends="use.init">
-    <calabash in="in.xml" out="out3.xml" inport="bogus" pipeline="pipeline.xpl" />
+    <calabash in="in.xml" out="out3.xml" inport="bogus" pipeline="pipeline.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
+    </calabash>
   </target>
 
   <target name="use.inport2" description="Use with real 'inport' value." depends="use.init">
-    <calabash in="in.xml" inport="source" out="out4.xml" pipeline="pipeline.xpl" />
+    <calabash in="in.xml" inport="source" out="out4.xml" pipeline="pipeline.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
+    </calabash>
   </target>
 
   <target name="use.outport" description="Use with bogus 'outport'." depends="use.init">
-    <calabash in="in.xml" out="out5.xml" outport="bogus" pipeline="pipeline.xpl" />
+    <calabash in="in.xml" out="out5.xml" outport="bogus" pipeline="pipeline.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
+    </calabash>
   </target>
 
   <target name="use.outport2" description="Use with real 'outport' value." depends="use.init">
-    <calabash in="in.xml" out="out6.xml" outport="result" pipeline="pipeline.xpl" />
+    <calabash in="in.xml" out="out6.xml" outport="result" pipeline="pipeline.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
+    </calabash>
   </target>
 
   <target name="use.nestedPipeline" description="Use with nested 'pipeline'" depends="use.init">
     <calabash in="in.xml" out="out7.xml">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
       <pipeline>
 	<file file="pipeline.xpl" />
       </pipeline>
     </calabash>
   </target>
 
+  <target name="use.multiport1" description="Use with multiple input ports." depends="use.init">
+    <calabash in="doc.xml" out="out8.xml" pipeline="compare-001.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
+      <input port="alternate">
+	<file file="doc.xml" />
+      </input>
+    </calabash>
+  </target>
+
 
   <target name="use"
 	  description="Try all"
-	  depends="use.basic,use.in2,use.inport2,use.outport,use.outport2,use.nestedPipeline"
+	  depends="use.basic,use.in2,use.inport2,use.inport2,use.outport,use.outport2,use.nestedPipeline,use.multiport1"
 	  />
 
 

--- a/test/build-task-test.xml
+++ b/test/build-task-test.xml
@@ -28,72 +28,6 @@
     </delete>
   </target>
 
-  <target name="use.init" description="Taskdef´ the Calabash-Task">
-    <taskdef name="calabash" classname="com.xmlcalabash.drivers.CalabashTask" classpath="${test.basedir}/../calabash.jar"/>
-  </target>
-
-
-  <target name="use.basic" description="Use without 'in', 'out', and 'pipeline'." depends="use.init">
-    <calabash in="in.xml" out="out1.xml" pipeline="pipeline.xpl">
-      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
-    </calabash>
-  </target>
-
-  <target name="use.in2" description="Use with different input." depends="use.init">
-    <calabash in="in2.xml" out="out2.xml" pipeline="pipeline.xpl">
-      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
-    </calabash>
-  </target>
-
-  <target name="use.inport" description="Use with bogus 'inport'." depends="use.init">
-    <calabash in="in.xml" out="out3.xml" inport="bogus" pipeline="pipeline.xpl">
-      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
-    </calabash>
-  </target>
-
-  <target name="use.inport2" description="Use with real 'inport' value." depends="use.init">
-    <calabash in="in.xml" inport="source" out="out4.xml" pipeline="pipeline.xpl">
-      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
-    </calabash>
-  </target>
-
-  <target name="use.outport" description="Use with bogus 'outport'." depends="use.init">
-    <calabash in="in.xml" out="out5.xml" outport="bogus" pipeline="pipeline.xpl">
-      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
-    </calabash>
-  </target>
-
-  <target name="use.outport2" description="Use with real 'outport' value." depends="use.init">
-    <calabash in="in.xml" out="out6.xml" outport="result" pipeline="pipeline.xpl">
-      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
-    </calabash>
-  </target>
-
-  <target name="use.nestedPipeline" description="Use with nested 'pipeline'" depends="use.init">
-    <calabash in="in.xml" out="out7.xml">
-      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
-      <pipeline>
-	<file file="pipeline.xpl" />
-      </pipeline>
-    </calabash>
-  </target>
-
-  <target name="use.multiport1" description="Use with multiple input ports." depends="use.init">
-    <calabash in="doc.xml" out="out8.xml" pipeline="compare-001.xpl">
-      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
-      <input port="alternate">
-	<file file="doc.xml" />
-      </input>
-    </calabash>
-  </target>
-
-
-  <target name="use"
-	  description="Try all"
-	  depends="use.basic,use.in2,use.inport2,use.inport2,use.outport,use.outport2,use.nestedPipeline,use.multiport1"
-	  />
-
-
   <target name="junit" description="Runs the unit tests">
     <delete dir="${junit.out.dir.xml}" />
     <mkdir  dir="${junit.out.dir.xml}" />
@@ -106,7 +40,7 @@
     </junit>
   </target>
 
-  <target name="junitreport" description="Create a report for the rest result">
+  <target name="junitreport" description="Create a report for the test result">
     <mkdir dir="${junit.out.dir.html}" />
     <junitreport todir="${junit.out.dir.html}">
       <fileset dir="${junit.out.dir.xml}">

--- a/test/build-task-test.xml
+++ b/test/build-task-test.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<project name="CalabashTask-test" basedir="." default="test">
+
+  <dirname property="test.basedir" file="${ant.file.CalabashTask-test}"/>
+  <property name="src.dir"     value="src"/>
+  <property name="classes.dir" value="classes"/>
+
+  <property name="ant.test.lib" value="ant-testutil.jar"/>
+  <property name="report.dir"   value="report"/>
+  <property name="junit.out.dir.xml"  value="${report.dir}/junit/xml"/>
+  <property name="junit.out.dir.html" value="${report.dir}/junit/html"/>
+
+  <path id="classpath.run">
+    <path path="${java.class.path}"/>
+    <path location="${test.basedir}/../calabash.jar"/>
+  </path>
+
+  <path id="classpath.test">
+    <path refid="classpath.run"/>
+    <path location="${ant.test.lib}"/>
+  </path>
+
+  <target name="clean" description="Delete all generated files">
+    <delete failonerror="false" includeEmptyDirs="true">
+      <fileset dir="." includes="${ant.project.name}.jar"/>
+      <fileset dir="${classes.dir}"/>
+      <fileset dir="${report.dir}"/>
+    </delete>
+  </target>
+
+  <target name="use.init" description="Taskdef´ the Calabash-Task">
+    <taskdef name="calabash" classname="com.xmlcalabash.drivers.CalabashTask" classpath="${test.basedir}/../calabash.jar"/>
+  </target>
+
+
+  <target name="use.without" description="Use without any" depends="use.init">
+    <calabash/>
+  </target>
+
+  <target name="use.message" description="Use with attribute 'message'" depends="use.init">
+    <calabash message="attribute-text"/>
+  </target>
+
+  <target name="use.fail" description="Use with attribute 'fail'" depends="use.init">
+    <calabash fail="true"/>
+  </target>
+
+  <target name="use.nestedText" description="Use with nested text" depends="use.init">
+    <calabash>nested-text</calabash>
+  </target>
+
+  <target name="use.nestedElement" description="Use with nested 'message'" depends="use.init">
+    <calabash>
+      <message msg="Nested Element 1"/>
+      <message msg="Nested Element 2"/>
+    </calabash>
+  </target>
+
+
+  <target name="use"
+	  description="Try all (w/out use.fail)"
+	  depends="use.without,use.message,use.nestedText,use.nestedElement"
+	  />
+
+
+  <target name="junit" description="Runs the unit tests">
+    <delete dir="${junit.out.dir.xml}" />
+    <mkdir  dir="${junit.out.dir.xml}" />
+    <junit printsummary="yes" haltonfailure="no">
+      <classpath refid="classpath.test"/>
+      <formatter type="xml"/>
+      <batchtest fork="yes" todir="${junit.out.dir.xml}">
+	<fileset dir="${src.dir}" includes="**/*Test.java"/>
+      </batchtest>
+    </junit>
+  </target>
+
+  <target name="junitreport" description="Create a report for the rest result">
+    <mkdir dir="${junit.out.dir.html}" />
+    <junitreport todir="${junit.out.dir.html}">
+      <fileset dir="${junit.out.dir.xml}">
+	<include name="*.xml"/>
+      </fileset>
+      <report format="frames" todir="${junit.out.dir.html}"/>
+    </junitreport>
+  </target>
+
+  <target name="test"
+	  depends="junit,junitreport"
+	  description="Runs unit tests and creates a report"
+	  />
+
+
+</project>

--- a/test/in/doc-alt.xml
+++ b/test/in/doc-alt.xml
@@ -1,0 +1,3 @@
+<doc>
+  <p>This is a para</p>
+</doc>

--- a/test/in/doc.xml
+++ b/test/in/doc.xml
@@ -1,0 +1,3 @@
+<doc>
+  <p>This is a para</p>
+</doc>

--- a/test/in/group-003_input1.xml
+++ b/test/in/group-003_input1.xml
@@ -1,0 +1,4 @@
+<document xmlns:t="http://xproc.org/ns/testsuite" xmlns:p="http://www.w3.org/ns/xproc" xmlns:c="http://www.w3.org/ns/xproc-step" xmlns:err="http://www.w3.org/ns/xproc-error">
+      <title>Some Title</title>
+      <para>Some paragraph.</para>
+    </document>

--- a/test/in/in.xml
+++ b/test/in/in.xml
@@ -1,0 +1,4 @@
+<document>
+  <title>Some Title</title>
+  <para>Some paragraph.</para>
+</document>

--- a/test/in/in2.xml
+++ b/test/in/in2.xml
@@ -1,0 +1,4 @@
+<document>
+  <title>Some Other Title</title>
+  <para>Some paragraph.</para>
+</document>

--- a/test/in/in3.xml
+++ b/test/in/in3.xml
@@ -1,0 +1,4 @@
+<document>
+  <title>Some Different Title</title>
+  <para>Same paragraph.</para>
+</document>

--- a/test/pipeline.xpl
+++ b/test/pipeline.xpl
@@ -1,0 +1,3 @@
+<p:pipeline version='1.0' name="pipeline" xmlns:p="http://www.w3.org/ns/xproc">
+  <p:add-attribute match="title" attribute-name="foo" attribute-value="bar"/>
+</p:pipeline>

--- a/test/suite2antunit.xsl
+++ b/test/suite2antunit.xsl
@@ -50,19 +50,27 @@
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:t="http://xproc.org/ns/testsuite"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:p="http://www.w3.org/ns/xproc"
     xmlns:c="http://www.w3.org/ns/xproc-step"
     xmlns:err="http://www.w3.org/ns/xproc-error"
     xmlns:au="antlib:org.apache.ant.antunit"
+    xmlns:m="http://www.mentea.net/resources"
     version="2.0"
-    exclude-result-prefixes="xs t c err au">
+    exclude-result-prefixes="xs t p c err au">
 
 <xsl:strip-space elements="t:*" />
 
 <xsl:param name="destdir"
 	   select="'antunit'"
 	   as="xs:string" />
+<xsl:param name="calabash.home"
+	   select="'/usr/local/src/xmlcalabash1'"
+	   as="xs:string" />
 <xsl:param name="antunit.home"
 	   select="'/usr/local/src/apache-ant-antunit-1.2'"
+	   as="xs:string" />
+<xsl:param name="sourcedir"
+	   select="m:dirname(/)"
 	   as="xs:string" />
 
 <xsl:template match="t:test-suite">
@@ -89,7 +97,7 @@
 
       <taskdef name="calabash"
 	       classname="com.xmlcalabash.drivers.CalabashTask"
-	       classpath="${{test.basedir}}/../../calabash.jar"/>
+	       classpath="{$calabash.home}/calabash.jar"/>
 
       <target name="antunit">
 	<au:antunit>
@@ -98,32 +106,47 @@
 	</au:antunit>
       </target>
 
-      <xsl:apply-templates select="t:test" />
+      <xsl:apply-templates select="document(t:test/@href)/t:test" />
     </project>
   </xsl:result-document>
-  <xsl:apply-templates select="t:test" mode="t:test" />
+  <xsl:apply-templates
+      select="document(t:test/@href)/t:test"
+      mode="t:test" />
 </xsl:template>
+
 <xsl:template match="t:title" />
 
 <xsl:template match="t:test">
   <xsl:variable
       name="test-doc"
-      select="document(@href, /)"
+      select="/"
       as="document-node()"/>
   <xsl:variable
       name="testdir"
-      select="replace(@href, '\.xml$', '')"
+      select="m:basename(m:dirname(base-uri(.)))"
+      as="xs:string" />
+  <xsl:variable
+      name="test-name"
+      select="m:basename(base-uri(.), '.xml')"
       as="xs:string" />
 
-  <target name="test_{translate(replace(@href, '\.xml$', ''), '/-', '__')}" description="{$test-doc/t:test/t:title}">
-    <echo message="{replace(@href, '\.xml$', '')}::{$test-doc/t:test/t:title}" />
+  <target name="test_{$testdir}_{translate($test-name, '-', '_')}"
+	  description="{t:title}">
+    <echo message="{$testdir}/{$test-name}::{t:title}" />
     <xsl:choose>
-      <xsl:when test="exists($test-doc/t:test/@error)">
-	<au:expectfailure>
+      <xsl:when test="exists(@error)">
+	<au:expectfailure expectedmessage="{substring-after(@error, 'err:')}">
 	  <xsl:call-template name="calabash-task">
-	    <xsl:with-param name="test-doc" select="$test-doc" as="document-node()" tunnel="yes" />
+	    <xsl:with-param name="test-doc"
+			    select="$test-doc"
+			    as="document-node()"
+			    tunnel="yes" />
 	    <xsl:with-param name="testdir"
 			    select="$testdir"
+			    as="xs:string"
+			    tunnel="yes" />
+	    <xsl:with-param name="test-name"
+			    select="$test-name"
 			    as="xs:string"
 			    tunnel="yes" />
 	  </xsl:call-template>
@@ -139,6 +162,10 @@
 			  select="$testdir"
 			  as="xs:string"
 			  tunnel="yes" />
+	  <xsl:with-param name="test-name"
+			  select="$test-name"
+			  as="xs:string"
+			  tunnel="yes" />
 	</xsl:call-template>
       </xsl:otherwise>
     </xsl:choose>
@@ -146,11 +173,32 @@
 </xsl:template>
 
 <xsl:template name="calabash-task">
-  <xsl:param name="test-doc" as="document-node()" tunnel="yes" required="yes" />
-  <xsl:param name="testdir" as="xs:string" tunnel="yes" required="yes" />
-  <calabash pipeline="{$testdir}/pipeline.xpl" useimplicitfileset="false">
+  <xsl:param name="test-doc"
+	     as="document-node()"
+	     tunnel="yes"
+	     required="yes" />
+  <xsl:param name="testdir"
+	     as="xs:string"
+	     tunnel="yes"
+	     required="yes" />
+  <xsl:param name="test-name"
+	     as="xs:string"
+	     tunnel="yes"
+	     required="yes" />
+
+  <calabash useimplicitfileset="false">
     <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
-    <xsl:for-each select="$test-doc/t:test/t:input">
+    <pipeline>
+      <xsl:choose>
+	<xsl:when test="exists(t:pipeline/@href)">
+	  <file file="{$testdir}/{t:pipeline/@href}" />
+	</xsl:when>
+	<xsl:otherwise>
+	  <file file="{$testdir}/{$test-name}_pipeline.xpl" />
+	</xsl:otherwise>
+      </xsl:choose>
+    </pipeline>
+    <xsl:for-each select="t:input">
       <input port="{@port}">
 	<xsl:choose>
 	  <xsl:when test="exists(t:document)">
@@ -163,18 +211,18 @@
 		  <file file="{$testdir}/{@href}" />
 		</xsl:when>
 		<xsl:otherwise>
-		  <file file="{$testdir}/input{$input-position}-{position()}.xml" />
+		  <file file="{$testdir}/{$test-name}_input{$input-position}-{position()}.xml" />
 		</xsl:otherwise>
 	      </xsl:choose>
 	    </xsl:for-each>
 	  </xsl:when>
 	  <xsl:otherwise>
-	    <file file="{$testdir}/input{position()}.xml" />
+	    <file file="{$testdir}/{$test-name}_input{position()}.xml" />
 	  </xsl:otherwise>
 	</xsl:choose>
       </input>
     </xsl:for-each>
-    <xsl:for-each select="$test-doc/t:test/t:output">
+    <xsl:for-each select="t:output">
       <output port="{@port}">
 	<xsl:choose>
 	  <xsl:when test="exists(t:document)">
@@ -184,16 +232,19 @@
 		  <file file="{$testdir}/{@href}" />
 		</xsl:when>
 		<xsl:otherwise>
-		  <file file="{$testdir}/{@port}-{position()}.xml" />
+		  <file file="{$testdir}/{$test-name}_{@port}-{position()}.xml" />
 		</xsl:otherwise>
 	      </xsl:choose>
 	    </xsl:for-each>
 	  </xsl:when>
 	  <xsl:otherwise>
-	    <file file="{$testdir}/{@port}.xml" />
+	    <file file="{$testdir}/{$test-name}_{@port}.xml" />
 	  </xsl:otherwise>
 	</xsl:choose>
       </output>
+    </xsl:for-each>
+    <xsl:for-each select="t:option">
+      <option name="{@name}" value="{@value}" />
     </xsl:for-each>
   </calabash>
 </xsl:template>
@@ -201,38 +252,42 @@
 <xsl:template match="t:test" mode="t:test">
   <xsl:variable
       name="test-doc"
-      select="document(@href, /)"
-      as="document-node()?"/>
-
-  <xsl:message>
-    <xsl:value-of select="@href" />
-    <xsl:text>:</xsl:text>
-    <xsl:value-of select="count($test-doc/t:test/t:input)" />
-    <xsl:text>:</xsl:text>
-    <xsl:value-of select="count($test-doc/t:test/t:output)" />
-  </xsl:message>
-
+      select="/"
+      as="document-node()"/>
   <xsl:variable
       name="testdir"
-      select="concat($destdir, '/', replace(@href, '\.xml$', ''))"
+      select="concat($destdir, '/', m:basename(m:dirname(base-uri(.))))"
+      as="xs:string" />
+  <xsl:variable
+      name="test-name"
+      select="m:basename(base-uri(.), '.xml')"
       as="xs:string" />
 
-  <xsl:for-each select="$test-doc/t:test/t:pipeline">
-    <xsl:result-document
-	href="{$testdir}/pipeline.xpl"
-	omit-xml-declaration="yes">
-      <xsl:choose>
-	<xsl:when test="exists(@href)">
-	  <xsl:copy-of select="document(@href, .)" />
-	</xsl:when>
-	<xsl:otherwise>
+<!--
+  <xsl:message>
+    <xsl:value-of select="$test-name" />
+    <xsl:text>:</xsl:text>
+    <xsl:value-of select="count(t:input)" />
+    <xsl:text>:</xsl:text>
+    <xsl:value-of select="count(t:output)" />
+  </xsl:message>
+-->
+
+  <xsl:for-each select="t:pipeline">
+    <xsl:choose>
+      <!-- External document will be handled separately. -->
+      <xsl:when test="exists(@href)" />
+      <xsl:otherwise>
+	<xsl:result-document
+	    href="{$testdir}/{$test-name}_pipeline.xpl"
+	    omit-xml-declaration="yes">
 	  <xsl:copy-of select="*" />
-	</xsl:otherwise>
-      </xsl:choose>
-    </xsl:result-document>
+	</xsl:result-document>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:for-each>
 
-  <xsl:for-each select="$test-doc/t:test/t:input">
+  <xsl:for-each select="t:input">
     <xsl:choose>
       <xsl:when test="exists(t:document)">
 	<xsl:variable name="input-position"
@@ -244,7 +299,7 @@
 	    <xsl:when test="exists(@href)" />
 	    <xsl:otherwise>
 	      <xsl:result-document
-		  href="{$testdir}/input{$input-position}-{position()}.xml"
+		  href="{$testdir}/{$test-name}_input{$input-position}-{position()}.xml"
 		  omit-xml-declaration="yes">
 		<xsl:copy-of select="*" />
 	      </xsl:result-document>
@@ -254,7 +309,7 @@
       </xsl:when>
       <xsl:otherwise>
 	<xsl:result-document
-	    href="{$testdir}/input{position()}.xml"
+	    href="{$testdir}/{$test-name}_input{position()}.xml"
 	    omit-xml-declaration="yes">
 	  <xsl:copy-of select="*" />
 	</xsl:result-document>
@@ -262,12 +317,12 @@
     </xsl:choose>
   </xsl:for-each>
 
-  <xsl:for-each select="$test-doc/t:test/t:output">
+  <xsl:for-each select="t:output">
     <xsl:choose>
       <xsl:when test="exists(t:document)">
 	<xsl:for-each select="t:document">
 	  <xsl:result-document
-	      href="{$testdir}/{../@port}-{position()}-ref.xml"
+	      href="{$testdir}/{$test-name}_{../@port}-{position()}-ref.xml"
 	      omit-xml-declaration="yes">
 	    <xsl:choose>
 	      <xsl:when test="exists(@href)">
@@ -282,13 +337,167 @@
       </xsl:when>
       <xsl:otherwise>
 	<xsl:result-document
-	    href="{$testdir}/{@port}-ref.xml"
+	    href="{$testdir}/{$test-name}_{@port}-ref.xml"
 	    omit-xml-declaration="yes">
 	  <xsl:copy-of select="*" />
 	</xsl:result-document>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:for-each>
+
+  <!-- Temporary solution for external files is to generate shell
+       commands to copy them to correct place. -->
+  <xsl:for-each select="t:pipeline/p:pipeline[@href] | t:pipeline//(p:import | p:document[@href]) | */t:document[@href]">
+    <xsl:if test="not(contains(@href, '..') or
+		      starts-with(@href, 'http') or
+		      starts-with(@href, 'unsupported:') or
+		      starts-with(@href, '#'))">
+      <xsl:if test="contains(@href, '/')">
+	<xsl:message>
+	  <xsl:text>mkdir -p </xsl:text>
+	  <xsl:value-of
+	      select="concat($testdir, '/', m:dirname(@href))" />
+	</xsl:message>
+      </xsl:if>
+      <xsl:value-of select="t:cp(concat(m:node-dirname(.), '/', @href),
+			         concat($testdir, '/', @href))" />
+    </xsl:if>
+  </xsl:for-each>
+</xsl:template>
+
+<xsl:function name="t:cp" as="empty-sequence()">
+  <xsl:param name="from" as="xs:string" />
+  <xsl:param name="to" as="xs:string" />
+
+    <xsl:message>
+      <xsl:text>cp </xsl:text>
+      <xsl:value-of select="$from" />
+      <xsl:text> </xsl:text>
+      <xsl:value-of select="$to" />
+    </xsl:message>
+</xsl:function>
+
+
+<!-- ============================================================= -->
+<!--                    FILENAME MUNGING FUNCTIONS                 -->
+<!-- ============================================================= -->
+
+<!-- Gets the last component of $uri. -->
+<xsl:function name="m:node-basename" as="xs:string">
+  <xsl:param name="node" as="node()" />
+
+  <xsl:sequence select="m:basename(base-uri($node))" />
+</xsl:function>
+
+<!-- Gets the last component of $uri. -->
+<xsl:function name="m:basename" as="xs:string">
+  <xsl:param name="uri" as="xs:string" />
+
+  <xsl:sequence select="tokenize($uri, '/')[last()]" />
+</xsl:function>
+
+<!-- Gets the last component of $uri. -->
+<xsl:function name="m:basename" as="xs:string">
+  <xsl:param name="uri" as="xs:string" />
+  <xsl:param name="suffix" as="xs:string" />
+
+  <xsl:variable name="suffix-regex"
+		select="replace(concat(if (starts-with($suffix, '.')) then '' else '.', $suffix, '$'), '\.', '\\.')"
+		as="xs:string" />
+
+  <xsl:sequence select="replace(tokenize($uri, '/')[last()], $suffix-regex, '')" />
+</xsl:function>
+
+<xsl:function name="m:node-dirname" as="xs:string">
+  <xsl:param name="node" as="node()" />
+
+  <xsl:sequence select="m:dirname(replace(base-uri($node), '^file:', ''))" />
+</xsl:function>
+
+<!-- dirname
+   - $uri: Pathname for which to get the directory name
+   -
+   - Gets the directory name (the part before the last $separator)
+   - of $string.
+   -->
+<xsl:function name="m:dirname" as="xs:string">
+  <xsl:param name="uri" as="xs:string" />
+
+  <xsl:sequence select="m:dirname($uri, '/')" />
+</xsl:function>
+
+<!-- dirname
+   - $uri: Pathname for which to get the directory name
+   - $separator: String separating directory names.
+   -
+   - Gets the directory name (the part before the last $separator)
+   - of $string.
+   -->
+<xsl:function name="m:dirname" as="xs:string">
+  <xsl:param name="uri" as="xs:string" />
+  <xsl:param name="separator" as="xs:string" />
+
+  <xsl:sequence
+      select="string-join(tokenize($uri, $separator)[position() &lt; last()],
+	                  $separator)" />
+
+</xsl:function>
+
+<!-- merge-dirnames
+     - $dirname1: Potential base for a relative directory name
+     - $dirname2: directory name to merge
+     - $separator: String to use when concatenating directories. Optional.
+     -
+     - Merge $dirname1 and $dirname2 such that if $dirname2 is
+     - a relative path, the result is relative to $dirname1.
+     -
+     - Also handles if either name or both names are empty.
+-->
+<xsl:template name="merge-dirnames">
+  <xsl:param name="dirname1"/>
+  <xsl:param name="dirname2"/>
+  <xsl:param name="separator" select="'/'"/>
+
+  <xsl:variable name="merged-dirname">
+    <xsl:choose>
+      <xsl:when test="substring($dirname2, 1, 5) = 'http:'">
+	<xsl:value-of select="$dirname2"/>
+      </xsl:when>
+      <xsl:when test="$dirname1 != ''">
+	<xsl:choose>
+	  <xsl:when test="$dirname2 != ''">
+	    <xsl:choose>
+	      <xsl:when test="substring($dirname2, 1, 1) = $separator">
+		<xsl:if test="substring($dirname1, 1, 7) = 'http://'">
+		  <xsl:value-of select="concat('http://',
+					substring-before(substring($dirname1, 8), '/'))"/>
+		</xsl:if>
+		<xsl:value-of select="$dirname2"/>
+	      </xsl:when>
+	      <xsl:otherwise>
+		<xsl:value-of select="concat($dirname1, $separator, $dirname2)"/>
+	      </xsl:otherwise>
+	    </xsl:choose>
+	  </xsl:when>
+	  <xsl:otherwise>
+	    <xsl:value-of select="$dirname1"/>
+	  </xsl:otherwise>
+	</xsl:choose>
+      </xsl:when>
+      <xsl:otherwise>
+	<xsl:choose>
+	  <xsl:when test="$dirname2">
+	    <xsl:value-of select="$dirname2"/>
+	  </xsl:when>
+	  <xsl:otherwise>
+	    <xsl:text>.</xsl:text>
+	  </xsl:otherwise>
+	</xsl:choose>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:variable>
+
+  <xsl:value-of select="$merged-dirname"/>
 </xsl:template>
 
 </xsl:stylesheet>

--- a/test/suite2antunit.xsl
+++ b/test/suite2antunit.xsl
@@ -1,0 +1,199 @@
+<!-- ============================================================= -->
+<!--  MODULE:     suite2antunit.xsl                                -->
+<!--  VERSION:    1                                                -->
+<!--  DATE:       15 May 2012                                      -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:      Calabash                                         -->
+<!--                                                               -->
+<!-- PURPOSE:     Generate a build file for use with antunit for   -->
+<!--              running the CalabashTask Ant task on the XProc   -->
+<!--              test suite.                                      -->
+<!--                                                               -->
+<!-- INPUT FILE:  Valid XProc test-suite XML                       -->
+<!--                                                               -->
+<!-- OUTPUT FILE: Ant build file.                                  -->
+<!--                                                               -->
+<!-- CREATED FOR: Calabash                                         -->
+<!--                                                               -->
+<!-- CREATED BY:  Mentea                                           -->
+<!--              13 Kelly's Bay Beach                             -->
+<!--              Skerries, Co. Dublin                             -->
+<!--              Ireland                                          -->
+<!--              http://www.mentea.net/                           -->
+<!--              info@mentea.net                                  -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--              15 May 2012                                      -->
+<!--                                                               -->
+<!-- CREATED BY: Tony Graham (tkg)                                 -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--               VERSION HISTORY                                 -->
+<!-- ============================================================= -->
+<!--
+ 1.  ORIGINAL VERSION                                 tkg 20120515
+                                                                   -->
+
+<!-- ============================================================= -->
+<!--                    DESIGN CONSIDERATIONS                      -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    XSL STYLESHEET INVOCATION                  -->
+<!-- ============================================================= -->
+
+<xsl:stylesheet
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:t="http://xproc.org/ns/testsuite"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:c="http://www.w3.org/ns/xproc-step"
+    xmlns:err="http://www.w3.org/ns/xproc-error"
+    version="2.0"
+    exclude-result-prefixes="xs t c err">
+
+<xsl:strip-space elements="t:*" />
+
+<xsl:param name="destdir"
+	   select="'antunit'"
+	   as="xs:string" />
+<xsl:param name="antunit.home"
+	   select="'/usr/local/src/apache-ant-antunit-1.2'"
+	   as="xs:string" />
+
+<xsl:template match="t:test-suite">
+  <xsl:result-document
+	href="{$destdir}/build-antunit.xml"
+	omit-xml-declaration="yes"
+	indent="yes">
+    <project name="CalabashTask-antunit"
+	     basedir="."
+	     xmlns:au="antlib:org.apache.ant.antunit">
+
+      <dirname property="test.basedir" file="${{ant.file.CalabashTask-antunit}}"/>
+
+      <property name="antunit.home" value="{$antunit.home}"/>
+
+      <taskdef 
+	  uri="antlib:org.apache.ant.antunit"
+	  resource="org/apache/ant/antunit/antlib.xml">
+	<classpath>
+	  <pathelement location="${{antunit.home}}/ant-antunit-1.2.jar"/>
+	</classpath>
+      </taskdef>
+
+      <taskdef name="calabash"
+	       classname="com.xmlcalabash.drivers.CalabashTask"
+	       classpath="${{test.basedir}}/../../calabash.jar"/>
+
+      <target name="antunit">
+	<au:antunit>
+	  <file file="build-antunit.xml"/>
+	  <au:plainlistener/>
+	</au:antunit>
+      </target>
+
+      <xsl:apply-templates select="t:test" />
+    </project>
+  </xsl:result-document>
+  <xsl:apply-templates select="t:test" mode="t:test" />
+</xsl:template>
+<xsl:template match="t:title" />
+
+<xsl:template match="t:test">
+  <xsl:variable
+      name="test-doc"
+      select="document(@href, /)"
+      as="document-node()?"/>
+  <xsl:variable
+      name="testdir"
+      select="replace(@href, '\.xml$', '')"
+      as="xs:string" />
+
+  <target name="test_{translate(replace(@href, '\.xml$', ''), '/-', '__')}" description="{$test-doc/t:test/t:title}">
+    <echo message="{replace(@href, '\.xml$', '')}::{$test-doc/t:test/t:title}" />
+    <calabash pipeline="{$testdir}/pipeline.xpl">
+      <sysproperty key="com.xmlcalabash.phonehome" value="false"/>
+      <xsl:for-each select="$test-doc/t:test/t:input">
+	<input port="{@port}">
+	  <file file="{$testdir}/input{position()}.xml" />
+	</input>
+      </xsl:for-each>
+      <xsl:for-each select="$test-doc/t:test/t:output">
+	<output port="{@port}">
+	  <file file="{$testdir}/{@port}.xml" />
+	</output>
+      </xsl:for-each>
+    </calabash>
+  </target>
+</xsl:template>
+
+<xsl:template match="t:test" mode="t:test">
+  <xsl:variable
+      name="test-doc"
+      select="document(@href, /)"
+      as="document-node()?"/>
+
+  <xsl:message>
+    <xsl:value-of select="@href" />
+    <xsl:text>:</xsl:text>
+    <xsl:value-of select="count($test-doc/t:test/t:input)" />
+    <xsl:text>:</xsl:text>
+    <xsl:value-of select="count($test-doc/t:test/t:output)" />
+  </xsl:message>
+
+  <xsl:variable
+      name="testdir"
+      select="concat($destdir, '/', replace(@href, '\.xml$', ''))"
+      as="xs:string" />
+
+  <xsl:for-each select="$test-doc/t:test/t:pipeline">
+    <xsl:result-document
+	href="{$testdir}/pipeline.xpl"
+	omit-xml-declaration="yes">
+      <xsl:choose>
+	<xsl:when test="exists(@href)">
+	  <xsl:copy-of select="document(@href, .)" />
+	</xsl:when>
+	<xsl:otherwise>
+	  <xsl:copy-of select="*" />
+	</xsl:otherwise>
+      </xsl:choose>
+    </xsl:result-document>
+  </xsl:for-each>
+
+  <xsl:for-each select="$test-doc/t:test/t:input">
+    <xsl:result-document
+	href="{$testdir}/input{position()}.xml"
+	omit-xml-declaration="yes">
+      <xsl:choose>
+	<xsl:when test="exists(@href)">
+	  <xsl:copy-of select="document(@href, .)" />
+	</xsl:when>
+	<xsl:otherwise>
+	  <xsl:copy-of select="*" />
+	</xsl:otherwise>
+      </xsl:choose>
+    </xsl:result-document>
+  </xsl:for-each>
+
+  <xsl:for-each select="$test-doc/t:test/t:output">
+    <xsl:result-document
+	href="{$testdir}/{@port}-ref.xml"
+	omit-xml-declaration="yes">
+      <xsl:choose>
+	<xsl:when test="exists(@href)">
+	  <xsl:copy-of select="document(@href, .)" />
+	</xsl:when>
+	<xsl:otherwise>
+	  <xsl:copy-of select="*" />
+	</xsl:otherwise>
+      </xsl:choose>
+    </xsl:result-document>
+  </xsl:for-each>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/test/suite2antunit.xsl
+++ b/test/suite2antunit.xsl
@@ -71,6 +71,7 @@
 	indent="yes">
     <project name="CalabashTask-antunit"
 	     basedir="."
+	     default="antunit"
 	     xmlns:au="antlib:org.apache.ant.antunit">
 
       <dirname property="test.basedir" file="${{ant.file.CalabashTask-antunit}}"/>


### PR DESCRIPTION
This adds (and even documents) an Ant task for running Calabash.

You can use this task to process:
- A single input file to produce a single output file
- A set of input files, processed one at a time, to produce a set of output files
- Multiple input files as the input to one XProc input port processed to produce a single output file
- Any of the above with additional input ports to each of which are applied one or more input files whose file names may be either fixed or mapped from the name(s) of the current main input file(s)
- Any of the above with additional output ports whose file names may be either fixed or mapped from the name(s) of the current main input file(s)

You can also specify options and parameters to be used by the pipeline.

This doesn't yet handle everything you can do from the Calabash command line or config file, but if it proves useful, then more can be added later.

The tests in `test/build-antunit.xml` do require AntUnit to run.

The license viewpoint is murky since it is influenced by the Ant `<xslt>` task code, among other reference sources, but it could never become part of Apache Ant itself because Calabash is licensed under GPL.
