### PR TITLE
Memory leak in extension functions and utils

### DIFF
--- a/src/com/xmlcalabash/functions/BaseURI.java
+++ b/src/com/xmlcalabash/functions/BaseURI.java
@@ -40,18 +40,10 @@ import com.xmlcalabash.core.XProcRuntime;
 
 public class BaseURI extends ExtensionFunctionDefinition {
     private static StructuredQName funcname = new StructuredQName("p", XProcConstants.NS_XPROC,"base-uri");
-    private ThreadLocal<XProcRuntime> tl_runtime = new ThreadLocal<XProcRuntime>() {
-        protected synchronized XProcRuntime initialValue() {
-            return null;
-        }
-    };
-
-    protected BaseURI() {
-        // you can't call this one
-    }
+    private final XProcRuntime runtime;
 
     public BaseURI(XProcRuntime runtime) {
-        tl_runtime.set(runtime);
+        this.runtime = runtime;
     }
 
     public StructuredQName getFunctionQName() {
@@ -86,7 +78,6 @@ public class BaseURI extends ExtensionFunctionDefinition {
         public SequenceIterator call(SequenceIterator[] arguments, XPathContext context) throws XPathException {
             String baseURI = null;
 
-            XProcRuntime runtime = tl_runtime.get();
             XStep step = runtime.getXProcData().getStep();
             // FIXME: this can't be the best way to do this...
             // step == null in use-when

--- a/src/com/xmlcalabash/functions/Cwd.java
+++ b/src/com/xmlcalabash/functions/Cwd.java
@@ -40,18 +40,10 @@ import com.xmlcalabash.core.XProcRuntime;
 
 public class Cwd extends ExtensionFunctionDefinition {
     private static StructuredQName funcname = new StructuredQName("exf", XProcConstants.NS_EXPROC_FUNCTIONS,"cwd");
-    private ThreadLocal<XProcRuntime> tl_runtime = new ThreadLocal<XProcRuntime>() {
-        protected synchronized XProcRuntime initialValue() {
-            return null;
-        }
-    };
-
-    protected Cwd() {
-        // you can't call this one
-    }
+    private final XProcRuntime runtime;
 
     public Cwd(XProcRuntime runtime) {
-        tl_runtime.set(runtime);
+        this.runtime = runtime;
     }
 
     public StructuredQName getFunctionQName() {
@@ -81,7 +73,6 @@ public class Cwd extends ExtensionFunctionDefinition {
     private class CwdCall extends ExtensionFunctionCall {
         public SequenceIterator call(SequenceIterator[] arguments, XPathContext context) throws XPathException {
 
-            XProcRuntime runtime = tl_runtime.get();
             XStep step = runtime.getXProcData().getStep();
             // FIXME: this can't be the best way to do this...
             // step == null in use-when

--- a/src/com/xmlcalabash/functions/IterationPosition.java
+++ b/src/com/xmlcalabash/functions/IterationPosition.java
@@ -40,18 +40,10 @@ import net.sf.saxon.value.SequenceType;
 
 public class IterationPosition extends ExtensionFunctionDefinition {
     private static StructuredQName funcname = new StructuredQName("p", XProcConstants.NS_XPROC, "iteration-position");
-    private ThreadLocal<XProcRuntime> tl_runtime = new ThreadLocal<XProcRuntime>() {
-        protected synchronized XProcRuntime initialValue() {
-            return null;
-        }
-    };
-
-    protected IterationPosition() {
-        // you can't call this one
-    }
+    private final XProcRuntime runtime;
 
     public IterationPosition(XProcRuntime runtime) {
-        tl_runtime.set(runtime);
+        this.runtime = runtime;
     }
 
     public StructuredQName getFunctionQName() {
@@ -80,7 +72,6 @@ public class IterationPosition extends ExtensionFunctionDefinition {
 
     private class IterationPositionCall extends ExtensionFunctionCall {
         public SequenceIterator call(SequenceIterator[] arguments, XPathContext context) throws XPathException {
-            XProcRuntime runtime = tl_runtime.get();
             XProcData data = runtime.getXProcData();
             XStep step = data.getStep();
             // FIXME: this can't be the best way to do this...

--- a/src/com/xmlcalabash/functions/IterationSize.java
+++ b/src/com/xmlcalabash/functions/IterationSize.java
@@ -39,18 +39,10 @@ import com.xmlcalabash.core.XProcConstants;
 
 public class IterationSize extends ExtensionFunctionDefinition {
     private static StructuredQName funcname = new StructuredQName("p", XProcConstants.NS_XPROC, "iteration-size");
-    private ThreadLocal<XProcRuntime> tl_runtime = new ThreadLocal<XProcRuntime>() {
-        protected synchronized XProcRuntime initialValue() {
-            return null;
-        }
-    };
-
-    protected IterationSize() {
-        // you can't call this one
-    }
+    private final XProcRuntime runtime;
 
     public IterationSize(XProcRuntime runtime) {
-        tl_runtime.set(runtime);
+        this.runtime = runtime;
     }
 
     public StructuredQName getFunctionQName() {
@@ -79,7 +71,6 @@ public class IterationSize extends ExtensionFunctionDefinition {
 
     private class IterationPositionCall extends ExtensionFunctionCall {
         public SequenceIterator call(SequenceIterator[] arguments, XPathContext context) throws XPathException {
-            XProcRuntime runtime = tl_runtime.get();
             XStep step = runtime.getXProcData().getStep();
             // FIXME: this can't be the best way to do this...
             // step == null in use-when

--- a/src/com/xmlcalabash/functions/ResolveURI.java
+++ b/src/com/xmlcalabash/functions/ResolveURI.java
@@ -44,18 +44,10 @@ import java.net.URISyntaxException;
 
 public class ResolveURI extends ExtensionFunctionDefinition {
     private static StructuredQName funcname = new StructuredQName("p", XProcConstants.NS_XPROC, "resolve-uri");
-    private ThreadLocal<XProcRuntime> tl_runtime = new ThreadLocal<XProcRuntime>() {
-        protected synchronized XProcRuntime initialValue() {
-            return null;
-        }
-    };
-
-    protected ResolveURI() {
-        // you can't call this one
-    }
+    private final XProcRuntime runtime;
 
     public ResolveURI(XProcRuntime runtime) {
-        tl_runtime.set(runtime);
+        this.runtime = runtime;
     }
 
     public StructuredQName getFunctionQName() {
@@ -91,7 +83,6 @@ public class ResolveURI extends ExtensionFunctionDefinition {
             SequenceIterator iter = arguments[0];
             String relativeURI = iter.next().getStringValue();
 
-            XProcRuntime runtime = tl_runtime.get();
             XStep step = runtime.getXProcData().getStep();
             // FIXME: this can't be the best way to do this...
             // step == null in use-when

--- a/src/com/xmlcalabash/functions/StepAvailable.java
+++ b/src/com/xmlcalabash/functions/StepAvailable.java
@@ -44,18 +44,10 @@ import com.xmlcalabash.model.DeclareStep;
 
 public class StepAvailable extends ExtensionFunctionDefinition {
     private static StructuredQName funcname = new StructuredQName("p", XProcConstants.NS_XPROC, "step-available");
-    private ThreadLocal<XProcRuntime> tl_runtime = new ThreadLocal<XProcRuntime>() {
-        protected synchronized XProcRuntime initialValue() {
-            return null;
-        }
-    };
-
-    protected StepAvailable() {
-        // you can't call this one
-    }
+    private final XProcRuntime runtime;
 
     public StepAvailable(XProcRuntime runtime) {
-        tl_runtime.set(runtime);
+        this.runtime = runtime;
     }
 
     public StructuredQName getFunctionQName() {
@@ -92,7 +84,6 @@ public class StepAvailable extends ExtensionFunctionDefinition {
         public SequenceIterator call(SequenceIterator[] arguments, XPathContext context) throws XPathException {
             StructuredQName stepName = null;
 
-            XProcRuntime runtime = tl_runtime.get();
             XStep step = runtime.getXProcData().getStep();
             // FIXME: this can't be the best way to do this...
             // step == null in use-when

--- a/src/com/xmlcalabash/functions/SystemProperty.java
+++ b/src/com/xmlcalabash/functions/SystemProperty.java
@@ -23,18 +23,10 @@ import com.xmlcalabash.core.XProcRuntime;
 
 public class SystemProperty extends ExtensionFunctionDefinition {
     private static StructuredQName funcname = new StructuredQName("p", XProcConstants.NS_XPROC, "system-property");
-    private ThreadLocal<XProcRuntime> tl_runtime = new ThreadLocal<XProcRuntime>() {
-        protected synchronized XProcRuntime initialValue() {
-            return null;
-        }
-    };
-
-     protected SystemProperty() {
-         // you can't call this one
-     }
+    private final XProcRuntime runtime;
 
      public SystemProperty(XProcRuntime runtime) {
-         tl_runtime.set(runtime);
+         this.runtime = runtime;
      }
 
      public StructuredQName getFunctionQName() {
@@ -71,7 +63,6 @@ public class SystemProperty extends ExtensionFunctionDefinition {
          public SequenceIterator call(SequenceIterator[] arguments, XPathContext context) throws XPathException {
              StructuredQName propertyName = null;
 
-             XProcRuntime runtime = tl_runtime.get();
              XStep step = runtime.getXProcData().getStep();
              // FIXME: this can't be the best way to do this...
              // FIXME: And what, exactly, is this even supposed to be doing!?

--- a/src/com/xmlcalabash/functions/ValueAvailable.java
+++ b/src/com/xmlcalabash/functions/ValueAvailable.java
@@ -45,18 +45,10 @@ import java.util.Hashtable;
 
 public class ValueAvailable extends ExtensionFunctionDefinition {
     private static StructuredQName funcname = new StructuredQName("p", XProcConstants.NS_XPROC, "value-available");
-    private ThreadLocal<XProcRuntime> tl_runtime = new ThreadLocal<XProcRuntime>() {
-        protected synchronized XProcRuntime initialValue() {
-            return null;
-        }
-    };
-
-    protected ValueAvailable() {
-        // you can't call this one
-    }
+    private final XProcRuntime runtime;
 
     public ValueAvailable(XProcRuntime runtime) {
-        tl_runtime.set(runtime);
+        this.runtime = runtime;
     }
 
     public StructuredQName getFunctionQName() {
@@ -93,7 +85,6 @@ public class ValueAvailable extends ExtensionFunctionDefinition {
         public SequenceIterator call(SequenceIterator[] arguments, XPathContext context) throws XPathException {
             StructuredQName sVarName = null;
 
-            XProcRuntime runtime = tl_runtime.get();
             XStep step = runtime.getXProcData().getStep();
             // FIXME: this can't be the best way to do this...
             // step == null in use-when

--- a/src/com/xmlcalabash/functions/VersionAvailable.java
+++ b/src/com/xmlcalabash/functions/VersionAvailable.java
@@ -40,18 +40,10 @@ import com.xmlcalabash.core.XProcRuntime;
 
 public class VersionAvailable extends ExtensionFunctionDefinition {
     private static StructuredQName funcname = new StructuredQName("p", XProcConstants.NS_XPROC, "version-available");
-    private ThreadLocal<XProcRuntime> tl_runtime = new ThreadLocal<XProcRuntime>() {
-        protected synchronized XProcRuntime initialValue() {
-            return null;
-        }
-    };
-
-    protected VersionAvailable() {
-        // you can't call this one
-    }
+    private final XProcRuntime runtime;
 
     public VersionAvailable(XProcRuntime runtime) {
-        tl_runtime.set(runtime);
+        this.runtime = runtime;
     }
 
     public StructuredQName getFunctionQName() {
@@ -82,7 +74,6 @@ public class VersionAvailable extends ExtensionFunctionDefinition {
         public SequenceIterator call(SequenceIterator[] arguments, XPathContext context) throws XPathException {
             SequenceIterator iter = arguments[0];
 
-            XProcRuntime runtime = tl_runtime.get();
             XStep step = runtime.getXProcData().getStep();
             // FIXME: this can't be the best way to do this...
             // step == null in use-when

--- a/src/com/xmlcalabash/functions/XPathVersionAvailable.java
+++ b/src/com/xmlcalabash/functions/XPathVersionAvailable.java
@@ -40,18 +40,10 @@ import com.xmlcalabash.core.XProcRuntime;
 
 public class XPathVersionAvailable extends ExtensionFunctionDefinition {
     private static StructuredQName funcname = new StructuredQName("p", XProcConstants.NS_XPROC, "xpath-version-available");
-    private ThreadLocal<XProcRuntime> tl_runtime = new ThreadLocal<XProcRuntime>() {
-        protected synchronized XProcRuntime initialValue() {
-            return null;
-        }
-    };
-
-    protected XPathVersionAvailable() {
-        // you can't call this one
-    }
+    private final XProcRuntime runtime;
 
     public XPathVersionAvailable(XProcRuntime runtime) {
-        tl_runtime.set(runtime);
+        this.runtime = runtime;
     }
 
     public StructuredQName getFunctionQName() {
@@ -82,7 +74,6 @@ public class XPathVersionAvailable extends ExtensionFunctionDefinition {
         public SequenceIterator call(SequenceIterator[] arguments, XPathContext context) throws XPathException {
             SequenceIterator iter = arguments[0];
 
-            XProcRuntime runtime = tl_runtime.get();
             XStep step = runtime.getXProcData().getStep();
             // FIXME: this can't be the best way to do this...
             // step == null in use-when

--- a/src/com/xmlcalabash/library/HttpRequest.java
+++ b/src/com/xmlcalabash/library/HttpRequest.java
@@ -322,11 +322,11 @@ public class HttpRequest extends DefaultStep {
         }
 
         TreeWriter tree = new TreeWriter(runtime);
-        tree.startDocument(requestURI);
 
         try {
             // Execute the method.
             int statusCode = client.executeMethod(httpResult);
+            tree.startDocument(URI.create(httpResult.getURI().getURI()));
 
             // Deal with cookies
             if (saveCookieKey != null) {

--- a/src/com/xmlcalabash/util/TypeUtils.java
+++ b/src/com/xmlcalabash/util/TypeUtils.java
@@ -44,8 +44,6 @@ public class TypeUtils {
     private static final QName err_XD0045 = new QName(XProcConstants.NS_XPROC_ERROR, "XD0045");
 
     private static int anonTypeCount = 0;
-    private static ItemTypeFactory typeFactory = null;
-    private static Hashtable<QName, ItemType> types = null;
 
     public static QName generateUniqueType(String baseName) {
         anonTypeCount++;
@@ -92,22 +90,13 @@ public class TypeUtils {
             return;
         }
 
-        if (typeFactory == null) {
-            typeFactory = new ItemTypeFactory(runtime.getProcessor());
-            types = new Hashtable<QName,ItemType> ();
-        }
+        ItemTypeFactory typeFactory = new ItemTypeFactory(runtime.getProcessor());
 
         ItemType itype = null;
-
-        if (types.containsKey(type)) {
-            itype = types.get(type);
-        } else {
-            try {
-                itype = typeFactory.getAtomicType(type);
-            } catch (SaxonApiException sae) {
-                throw new XProcException("Unexpected type: " + type);
-            }
-            types.put(type,itype);
+        try {
+            itype = typeFactory.getAtomicType(type);
+        } catch (SaxonApiException sae) {
+            throw new XProcException("Unexpected type: " + type);
         }
 
         // FIXME: There's probably a less expensive expensive way to do this


### PR DESCRIPTION
The use of ThreadLocal and static fields prevent XProcRuntime (and its references) from being gc'd. This patch removes those references, while maintaining the current API.
