### PR TITLE
URI resolution chokes on URI scheme not supported by JVM

### DIFF
--- a/src/com/xmlcalabash/util/XProcURIResolver.java
+++ b/src/com/xmlcalabash/util/XProcURIResolver.java
@@ -107,10 +107,9 @@ public class XProcURIResolver implements URIResolver, EntityResolver {
                     absoluteURI = new URL(new URL(base), href);
                 }
             } catch (MalformedURLException mue) {
-                throw new XProcException(mue);
             }
 
-            Source resolved = uriResolver.resolve(absoluteURI.toString(), base);
+            Source resolved = uriResolver.resolve(absoluteURI == null ? href : absoluteURI.toString(), base);
 
             // FIXME: This is a grotesque hack. This is wrong. Wrong. Wrong.
             // To support caching, XMLResolver (xmlresolver.org) returns a Source even when it hasn't


### PR DESCRIPTION
I am using Calabash with a custom `URIResolver` that resolves URIs of the `site` scheme (e.g. `site:/pages/index.html`).

Unfortunately, Calabash's `XProcURIResolver` tries to construct a `java.net.URL`  from the URI, and since the running JVM doesn't have a handler for the `site` scheme, this fails, even though the custom `URIResolver` would translate it into something usable.

This is a patch for that problem. Now, the `MalformedURLException` is caught and ignored, and the unaltered input URI used if a `java.net.URL` could not be constructed. I'm not familiar with the `jar` URI use case your code there is meant to address, but I'm hoping this change won't break that use case.
