### PR TITLE
Allow multiple saxon processors to be used

### DIFF
--- a/src/com/xmlcalabash/util/TypeUtils.java
+++ b/src/com/xmlcalabash/util/TypeUtils.java
@@ -44,8 +44,6 @@ public class TypeUtils {
     private static final QName err_XD0045 = new QName(XProcConstants.NS_XPROC_ERROR, "XD0045");
 
     private static int anonTypeCount = 0;
-    private static ItemTypeFactory typeFactory = null;
-    private static Hashtable<QName, ItemType> types = null;
 
     public static QName generateUniqueType(String baseName) {
         anonTypeCount++;
@@ -92,22 +90,14 @@ public class TypeUtils {
             return;
         }
 
-        if (typeFactory == null) {
-            typeFactory = new ItemTypeFactory(runtime.getProcessor());
-            types = new Hashtable<QName,ItemType> ();
-        }
+        ItemTypeFactory typeFactory = new ItemTypeFactory(runtime.getProcessor());
 
         ItemType itype = null;
 
-        if (types.containsKey(type)) {
-            itype = types.get(type);
-        } else {
-            try {
-                itype = typeFactory.getAtomicType(type);
-            } catch (SaxonApiException sae) {
-                throw new XProcException("Unexpected type: " + type);
-            }
-            types.put(type,itype);
+        try {
+            itype = typeFactory.getAtomicType(type);
+        } catch (SaxonApiException sae) {
+            throw new XProcException("Unexpected type: " + type);
         }
 
         // FIXME: There's probably a less expensive expensive way to do this


### PR DESCRIPTION
XProcRuntime can only be configured with a single set of resolvers and listeners, and due to the use of ThreadLocal variables in extension function, XProcRuntime can only be used by a single thread.

Due to the tight relationship between XProcRuntime and the saxon Processor (registerExtensionFunction, setURIResolver, and setErrorListener), is not always possible to use the same saxon Processor for all operations in the JVM.

This patch allows multiple saxon processors and therefore multiple XProcRuntimes with the TypeUtils class.
