### PR TITLE
Memory leak in extension functions

### DIFF
--- a/src/com/xmlcalabash/functions/XProcExtensionFunctionDefinition.java
+++ b/src/com/xmlcalabash/functions/XProcExtensionFunctionDefinition.java
@@ -21,6 +21,6 @@ public abstract class XProcExtensionFunctionDefinition extends ExtensionFunction
     };
 
     public void close() {
-        tl_runtime.set(null);
+        tl_runtime.remove();
     }
 }


### PR DESCRIPTION
This patch cleans up the java.lang.ThreadLocal.ThreadLocalMap.Entry object that is left in the thread for every XProcExtensionFunctionDefinition of every XProcRuntime.
