### PR TITLE
Fix a mem leak in TreeWriter

### DIFF
--- a/src/com/xmlcalabash/util/TreeWriter.java
+++ b/src/com/xmlcalabash/util/TreeWriter.java
@@ -115,6 +115,7 @@ public class TreeWriter {
     public void endDocument() {
         try {
             receiver.endDocument();
+            receiver.close();
         } catch (XPathException e) {
             throw new XProcException(e);
         }


### PR DESCRIPTION
Saxon's Receiver instance was not closed in TreeWriter. This change closes it in the TreeWriter#endDocument method.
