### PR TITLE
Better XdmNode to InputSource conversion

### DIFF
--- a/src/com/xmlcalabash/util/S9apiUtils.java
+++ b/src/com/xmlcalabash/util/S9apiUtils.java
@@ -205,7 +205,9 @@ public class S9apiUtils {
         Serializer serializer = new Serializer();
         serializer.setOutputStream(out);
         serialize(runtime, node, serializer);
-        return new InputSource(new ByteArrayInputStream(out.toByteArray()));
+        InputSource isource = new InputSource(new ByteArrayInputStream(out.toByteArray()));
+        isource.setSystemId(node.getBaseURI().toASCIIString());
+        return isource;
     }
 
     public static HashSet<String> excludeInlinePrefixes(XdmNode node, String prefixList) {

--- a/src/com/xmlcalabash/util/S9apiUtils.java
+++ b/src/com/xmlcalabash/util/S9apiUtils.java
@@ -20,9 +20,25 @@
 
 package com.xmlcalabash.util;
 
-import com.xmlcalabash.core.XProcConstants;
-import com.xmlcalabash.core.XProcException;
-import net.sf.saxon.om.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.net.URI;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Vector;
+
+import net.sf.saxon.Configuration;
+import net.sf.saxon.event.NamespaceReducer;
+import net.sf.saxon.event.PipelineConfiguration;
+import net.sf.saxon.event.Receiver;
+import net.sf.saxon.event.TreeReceiver;
+import net.sf.saxon.om.FingerprintedQName;
+import net.sf.saxon.om.InscopeNamespaceResolver;
+import net.sf.saxon.om.Item;
+import net.sf.saxon.om.NameOfNode;
+import net.sf.saxon.om.NamespaceBinding;
+import net.sf.saxon.om.NodeInfo;
+import net.sf.saxon.om.NodeName;
 import net.sf.saxon.s9api.Axis;
 import net.sf.saxon.s9api.Destination;
 import net.sf.saxon.s9api.Processor;
@@ -42,21 +58,13 @@ import net.sf.saxon.s9api.XdmNodeKind;
 import net.sf.saxon.s9api.XdmSequenceIterator;
 import net.sf.saxon.s9api.XdmValue;
 import net.sf.saxon.trans.XPathException;
-import net.sf.saxon.event.Receiver;
-import net.sf.saxon.event.TreeReceiver;
-import net.sf.saxon.event.NamespaceReducer;
-import net.sf.saxon.event.PipelineConfiguration;
-import net.sf.saxon.Configuration;
-import com.xmlcalabash.core.XProcRuntime;
-import java.util.Iterator;
-import java.util.Vector;
-import java.util.HashSet;
-import java.net.URI;
-import java.io.StringWriter;
-import java.io.StringReader;
-
 import net.sf.saxon.tree.util.NamespaceIterator;
+
 import org.xml.sax.InputSource;
+
+import com.xmlcalabash.core.XProcConstants;
+import com.xmlcalabash.core.XProcException;
+import com.xmlcalabash.core.XProcRuntime;
 
 /**
  *
@@ -193,17 +201,11 @@ public class S9apiUtils {
 
     // FIXME: THIS METHOD IS A GROTESQUE HACK!
     public static InputSource xdmToInputSource(XProcRuntime runtime, XdmNode node) throws SaxonApiException {
-        StringWriter sw = new StringWriter();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
         Serializer serializer = new Serializer();
-        serializer.setOutputWriter(sw);
+        serializer.setOutputStream(out);
         serialize(runtime, node, serializer);
-
-        String serxml = sw.toString();
-
-        StringReader sr = new StringReader(serxml);
-        InputSource isource = new InputSource(sr);
-        isource.setSystemId(node.getBaseURI().toASCIIString());
-        return isource;
+        return new InputSource(new ByteArrayInputStream(out.toByteArray()));
     }
 
     public static HashSet<String> excludeInlinePrefixes(XdmNode node, String prefixList) {


### PR DESCRIPTION
The proposed change serializes the XdmNode to a temporary ByteArray instead of a String. It's more efficient and prevents some OutOfMemoryErrors.
