### PR TITLE
Tweaks to the Maven and OSGi build files

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -503,21 +503,10 @@ java -Xmx1024m -jar %INSTALL_PATH/calabash.jar "$@"
              classpathref="build.classpath"/>
   </target>
 
-  <target name="maven-dist" depends="init,compile-everything,javadoc"
+  <target name="maven-dist" depends="init,compile-everything,jar,javadoc"
           description="generate Maven jars">
-    <!-- build the main artifact -->
-    <jar destfile="${maven-jar}">
-      <manifest>
-        <attribute name="Built-By" value="${built.by}"/>
-        <attribute name="Implementation-Vendor" value="${implementation.vendor}"/>
-        <attribute name="Implementation-Title" value="${implementation.title}"/>
-        <attribute name="Implementation-Version" value="${dist-version}"/>
-        <attribute name="Main-Class" value="com.xmlcalabash.drivers.Main"/>
-        <attribute name="Class-Path" value="${run.classpath}"/>
-      </manifest>
-
-      <fileset dir="${build.dir}"/>
-    </jar>
+    <!-- copy the main artifact -->
+    <copy file="calabash.jar" toFile="${maven-jar}"/>
 
     <!-- build the sources artifact -->
     <jar jarfile="${maven-sources-jar}">

--- a/osgi/calabash.bnd
+++ b/osgi/calabash.bnd
@@ -11,12 +11,9 @@ Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Export-Package: *, etc
 Import-Package: \
   net.sf.saxon.*;version=${if;${def;saxon94};9.4.0;9.3.0},\
-  com.sun.msv.*;resolution:=optional,\
-  com.thaiopensource.*;resolution:=optional,\
-  nu.validator.*;resolution:=optional,\
-  org.apache.tools.ant.*;resolution:=optional,\
-  org.ccil.cowan.tagsoup;resolution:=optional,\
-  org.iso_relax.verifier;resolution:=optional,\
-  org.w3c.dom;resolution:=optional,\
-  *
+  javax.crypto.*,\
+  javax.xml.*,\
+  org.apache.commons.httpclient.*,\
+  org.xml.sax.*,\
+  *;resolution:=optional
 DynamicImport-Package: *

--- a/pom.xml
+++ b/pom.xml
@@ -5,9 +5,9 @@
                              http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
+
   <groupId>com.xmlcalabash</groupId>
   <artifactId>xmlcalabash</artifactId>
-  <!-- This will be updated by Ant -->
   <version>@version@</version>
   <name>XML Calabash</name>
   <description>XML Calabash - an implementation of XProc: An XML Pipeline Language</description>
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>net.sf.saxon</groupId>
       <artifactId>Saxon-HE</artifactId>
-      <version>9.4</version>
+      <version>9.4.0.7</version>
     </dependency>
 
     <!-- No need to specify commons-logging or commons-codec - they're transitive dependencies of commons-httpclient -->
@@ -70,29 +70,47 @@
       <groupId>com.thaiopensource</groupId>
       <artifactId>jing</artifactId>
       <version>20091111</version>
+      <optional>true</optional><!-- used in the p:validate-with-rng step and NVDL extension -->
       <exclusions>
         <exclusion>
           <groupId>net.sf.saxon</groupId>
           <artifactId>saxon</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>xml-apis</groupId>
+          <artifactId>xml-apis</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.mail</groupId>
+      <artifactId>javax.mail-api</artifactId>
+      <version>1.4.5</version>
+      <optional>true</optional>
     </dependency>
 
     <dependency>
       <groupId>org.ccil.cowan.tagsoup</groupId>
       <artifactId>tagsoup</artifactId>
       <version>1.2.1</version>
+      <optional>true</optional><!-- used in p:unescapte-markup optional TagSoup HTML parser implementation -->
     </dependency>
 
-    <!-- @todo nu.validator.htmlparser version 1.3.1 doesn't exist in Maven yet.
-               Version 1.2.1 does. -->
-    <!--
-        <dependency>
-          <groupId>nu.validator.htmlparser</groupId>
-          <artifactId>htmlparser</artifactId>
-          <version>1.3.1</version>
-        </dependency>
-    -->
+    <dependency>
+      <groupId>nu.validator.htmlparser</groupId>
+      <artifactId>htmlparser</artifactId>
+      <version>1.4</version>
+      <optional>true</optional><!-- used in the p:unescapte-markup Validator.nu default HTML parser implementation -->
+    </dependency>
+
+    <dependency>
+      <groupId>xmlunit</groupId>
+      <artifactId>xmlunit</artifactId>
+      <version>1.3</version>
+      <optional>true</optional><!-- used in the cxu:compare extension -->
+    </dependency>
+
   </dependencies>
 
   <distributionManagement>


### PR DESCRIPTION
- the `maven-dist` target now copies over the jar built from the `jar` target
  (instead of re-packaging from scratch). This notably means the maven
  artifact will contain the OSGi metadata added by the `jar` target.
- in the OSGi bnd configuration file (used to generate OSGi metadata), only
  the required packages are explicitly listed, all the other package dependencies
  are set as optional. This notably means that all the proprietary libs in
  the classpath of the `compile-everything` target will be declared as optional
  dependencies in the OSGi manifest.
- in the Maven POM, updated Saxon's version to 9.4.0.7.
- in the Maven POM, made the Jing and TagSoup dependencies optional
- in the Maven POM, added an optional dependency for Henri Sivonen's
  html-parser (back in Maven since version 1.4)
- in the Maven POM, added optional dependencies for javax.mail and
  xmlunit.
