### PR TITLE
Adapted the configurer to XProcProcessor/XProcRuntime...

### DIFF
--- a/resources/etc/version.properties
+++ b/resources/etc/version.properties
@@ -1,3 +1,3 @@
 version.major=1
 version.minor=0
-version.release=9a
+version.release=9a-11dev

--- a/src/com/xmlcalabash/config/XMLCalabashConfigurer.java
+++ b/src/com/xmlcalabash/config/XMLCalabashConfigurer.java
@@ -1,5 +1,6 @@
 package com.xmlcalabash.config;
 
+import com.xmlcalabash.core.XProcProcessor;
 import com.xmlcalabash.core.XProcRuntime;
 import com.xmlcalabash.io.ReadablePipe;
 import com.xmlcalabash.library.Load;
@@ -15,6 +16,7 @@ import net.sf.saxon.s9api.XdmNode;
  * To change this template use File | Settings | File Templates.
  */
 public interface XMLCalabashConfigurer {
+    public void configProcessor(XProcProcessor processor);
     public void configRuntime(XProcRuntime runtime);
     public XdmNode loadDocument(Load load);
     public ReadablePipe makeReadableData(XProcRuntime runtime, DataBinding binding);

--- a/src/com/xmlcalabash/core/XProcProcessor.java
+++ b/src/com/xmlcalabash/core/XProcProcessor.java
@@ -3,28 +3,20 @@ package com.xmlcalabash.core;
 import com.xmlcalabash.config.XProcConfigurer;
 import com.xmlcalabash.util.DefaultXProcConfigurer;
 import com.xmlcalabash.util.DefaultXProcMessageListener;
-import com.xmlcalabash.util.JSONtoXML;
 import com.xmlcalabash.util.StepErrorListener;
 import com.xmlcalabash.util.URIUtils;
 import com.xmlcalabash.util.XProcURIResolver;
 import net.sf.saxon.Configuration;
 import net.sf.saxon.lib.ExtensionFunctionDefinition;
-import net.sf.saxon.lib.UnparsedTextURIResolver;
 import net.sf.saxon.s9api.ExtensionFunction;
 import net.sf.saxon.s9api.Processor;
 import net.sf.saxon.s9api.QName;
 import net.sf.saxon.s9api.SaxonApiException;
 import net.sf.saxon.s9api.XdmNode;
-import net.sf.saxon.trans.XPathException;
 import org.xml.sax.EntityResolver;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
 
-import javax.xml.transform.Source;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.URIResolver;
-import java.io.IOException;
-import java.io.Reader;
 import java.lang.reflect.Constructor;
 import java.net.URI;
 import java.util.logging.Logger;
@@ -80,6 +72,7 @@ public class XProcProcessor {
         } else {
             configurer = new DefaultXProcConfigurer(this);
         }
+        configurer.getXMLCalabashConfigurer().configProcessor(this);
 
         Configuration saxonConfig = processor.getUnderlyingConfiguration();
         saxonConfig.setURIResolver(uriResolver);
@@ -117,6 +110,7 @@ public class XProcProcessor {
 
     public void setConfigurer(XProcConfigurer configurer) {
         this.configurer = configurer;
+        configurer.getXMLCalabashConfigurer().configProcessor(this);
     }
 
     public XProcMessageListener getMessageListener() {

--- a/src/com/xmlcalabash/core/XProcProcessor.java
+++ b/src/com/xmlcalabash/core/XProcProcessor.java
@@ -246,17 +246,17 @@ public class XProcProcessor {
 
         @Override
         public void warning(TransformerException e) throws TransformerException {
-            throw new RuntimeException("Processor Error Listener Called");
+            msgListener.warning(e);
         }
 
         @Override
         public void error(TransformerException e) throws TransformerException {
-            throw new RuntimeException("Processor Error Listener Called");
+            msgListener.warning(e);
         }
 
         @Override
         public void fatalError(TransformerException e) throws TransformerException {
-            throw new RuntimeException("Processor Error Listener Called");
+            msgListener.error(e);
         }
     }
 }

--- a/src/com/xmlcalabash/util/DefaultXMLCalabashConfigurer.java
+++ b/src/com/xmlcalabash/util/DefaultXMLCalabashConfigurer.java
@@ -28,8 +28,8 @@ public class DefaultXMLCalabashConfigurer implements XMLCalabashConfigurer {
     private final static QName cx_filemask = new QName("cx", XProcConstants.NS_CALABASH_EX,"filemask");
     protected XProcProcessor xproc = null;
 
-    public DefaultXMLCalabashConfigurer(XProcProcessor xproc) {
-        this.xproc = xproc;
+    public void configProcessor(XProcProcessor processor) {
+        xproc = processor;
     }
 
     public void configRuntime(XProcRuntime runtime) {
@@ -37,6 +37,9 @@ public class DefaultXMLCalabashConfigurer implements XMLCalabashConfigurer {
     }
 
     public XdmNode loadDocument(Load load) {
+        if ( xproc == null ) {
+            throw new XProcException("This configurer has not been set to a processor: " + this);
+        }
         boolean      validate = load.getOption(_dtd_validate, false);
         RuntimeValue href     = load.getOption(_href);
         String       base     = href.getBaseURI().toASCIIString();

--- a/src/com/xmlcalabash/util/DefaultXProcConfigurer.java
+++ b/src/com/xmlcalabash/util/DefaultXProcConfigurer.java
@@ -6,7 +6,6 @@ import com.xmlcalabash.config.SaxonConfigurer;
 import com.xmlcalabash.config.XMLCalabashConfigurer;
 import com.xmlcalabash.config.XProcConfigurer;
 import com.xmlcalabash.core.XProcProcessor;
-import com.xmlcalabash.core.XProcRuntime;
 
 /**
  * Created by IntelliJ IDEA.
@@ -22,7 +21,7 @@ public class DefaultXProcConfigurer implements XProcConfigurer {
     private XMLCalabashConfigurer configurer = null;
 
     public DefaultXProcConfigurer(XProcProcessor xproc) {
-        configurer = new DefaultXMLCalabashConfigurer(xproc);
+        configurer = new DefaultXMLCalabashConfigurer();
     }
 
     public XMLCalabashConfigurer getXMLCalabashConfigurer() {


### PR DESCRIPTION
Added the method configureProcessor to the XMLCalabashConfigurer interface, and call it appropriately in the XProcProcessor. Changed the version number on the 1.1-dev branch.
