### PR TITLE
Add javac class target version

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -154,7 +154,7 @@
 
     <javac destdir="${build.dir}"
 	   classpathref="build.classpath"
-           includeantruntime="false"
+           source="1.6" target="1.6" includeantruntime="false"
 	   debug="${javac.debug}">
       <!--
       <compilerarg value="-Xlint"/>
@@ -181,7 +181,7 @@
   <!-- this target won't work unless you have all the optional/commercial jars -->
   <target name="compile-everything" depends="init,update-output">
     <javac destdir="${build.dir}"
-           includeantruntime="false">
+           source="1.6" target="1.6" includeantruntime="false">
       <classpath>
         <!-- Yes, I know these are explicit. This target is really only for me. -->
         <fileset dir="lib">
@@ -213,7 +213,7 @@
   <target name="compile-XMLUnit" depends="init" if="XMLUnit.present">
     <javac destdir="${build.dir}"
 	   classpathref="build.classpath"
-           includeantruntime="false">
+           source="1.6" target="1.6" includeantruntime="false">
       <src path="src"/>
       <include name="com/xmlcalabash/extensions/xmlunit/Compare.java"/>
     </javac>
@@ -226,7 +226,7 @@
   <target name="compile-XCC" depends="init" if="MarkLogicXCC.present">
     <javac destdir="${build.dir}"
 	   classpathref="build.classpath"
-           includeantruntime="false">
+           source="1.6" target="1.6" includeantruntime="false">
       <src path="src"/>
       <include name="com/xmlcalabash/extensions/marklogic/XCCAdhocQuery.java"/>
       <include name="com/xmlcalabash/extensions/marklogic/XCCInsertDocument.java"/>
@@ -241,7 +241,7 @@
   <target name="compile-MetadataException" depends="init" if="MetadataException.present">
     <javac destdir="${build.dir}"
 	   classpathref="build.classpath"
-           includeantruntime="false">
+           source="1.6" target="1.6" includeantruntime="false">
       <!--
       <compilerarg value="-Xlint"/>
       -->
@@ -257,7 +257,7 @@
   <target name="compile-DeltaXML" depends="init" if="DeltaXML.present">
     <javac destdir="${build.dir}"
 	   classpathref="build.classpath"
-           includeantruntime="false">
+           source="1.6" target="1.6" includeantruntime="false">
       <src path="src"/>
       <include name="com/xmlcalabash/extensions/DeltaXML.java"/>
     </javac>
@@ -270,7 +270,7 @@
   <target name="compile-XEP" depends="init" if="XEP.present">
     <javac destdir="${build.dir}"
 	   classpathref="build.classpath"
-           includeantruntime="false">
+           source="1.6" target="1.6" includeantruntime="false">
       <src path="src"/>
       <include name="com/xmlcalabash/util/FoXEP.java"/>
     </javac>
@@ -283,7 +283,7 @@
   <target name="compile-AH" depends="init" if="AH.present">
     <javac destdir="${build.dir}"
 	   classpathref="build.classpath"
-           includeantruntime="false">
+           source="1.6" target="1.6" includeantruntime="false">
       <src path="src"/>
       <include name="com/xmlcalabash/util/FoAH.java"/>
       <include name="com/xmlcalabash/util/CssAH.java"/>
@@ -297,7 +297,7 @@
   <target name="compile-SendMail" depends="init" if="Mail.present">
     <javac destdir="${build.dir}"
 	   classpathref="build.classpath"
-           includeantruntime="false">
+           source="1.6" target="1.6" includeantruntime="false">
       <src path="src"/>
       <include name="com/xmlcalabash/extensions/SendMail.java"/>
     </javac>
@@ -324,7 +324,7 @@
   <target name="compile-FOP" depends="init" if="FOP.present">
     <javac destdir="${build.dir}"
 	   classpathref="build.classpath"
-           includeantruntime="false">
+           source="1.6" target="1.6" includeantruntime="false">
       <src path="src"/>
       <include name="com/xmlcalabash/util/FoFOP.java"/>
     </javac>


### PR DESCRIPTION
The target Java class binary version should be explicit in the build.xml file for repeatable builds.
