### PR TITLE
Reinstate Maven uploads

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -516,7 +516,7 @@ java -Xmx1024m -jar %INSTALL_PATH/calabash.jar "$@"
     <!-- Update the version in the POM -->
     <copy file="pom.xml" toFile="${maven.dir}/pom.xml">
       <filterset>
-        <filter token="version" value="${version}"/>
+        <filter token="version" value="${mvn-version}"/>
       </filterset>
     </copy>
   </target>

--- a/build.xml
+++ b/build.xml
@@ -56,7 +56,7 @@
     <!-- define Maven coordinates -->
     <property name="groupId" value="com.xmlcalabash" />
     <property name="artifactId" value="xmlcalabash" />
-    <property name="mvn-version" value="${version}-${saxon-version}"/>
+    <property name="mvn-version" value="${version}-${saxon-version-short}"/>
 
     <!-- define artifact names, which follow the convention of Maven -->
     <property name="maven.dir" value="${dist.dir}/maven" />
@@ -100,16 +100,18 @@
 
   <target name="init" depends="saxon-version">
     <mkdir dir="${build.dir}"/>
-    <property name="dist-version" value="${version}-${saxon-version}"/>
+    <property name="dist-version" value="${version}-${saxon-version-short}"/>
     <property name="install.dir" value="${dist.dir}/calabash-${dist-version}"/>
   </target>
 
   <target name="saxon94" if="saxon94">
-    <property name="saxon-version" value="94"/>
+    <property name="saxon-version-short" value="94"/>
+    <property name="saxon-version" value="9.4.0.7"/>
   </target>
 
   <target name="saxon93" unless="saxon94">
-    <property name="saxon-version" value="93"/>
+    <property name="saxon-version-short" value="93"/>
+    <property name="saxon-version" value="9.3.0"/>
   </target>
 
   <target name="saxon-version" depends="saxon93,saxon94">
@@ -517,6 +519,7 @@ java -Xmx1024m -jar %INSTALL_PATH/calabash.jar "$@"
     <copy file="pom.xml" toFile="${maven.dir}/pom.xml">
       <filterset>
         <filter token="version" value="${mvn-version}"/>
+        <filter token="saxon-version" value="${saxon-version}"/>
       </filterset>
     </copy>
   </target>

--- a/osgi/calabash.bnd
+++ b/osgi/calabash.bnd
@@ -10,7 +10,7 @@ Bundle-Version: ${dist-version}
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Export-Package: *, etc
 Import-Package: \
-  net.sf.saxon.*;version=${if;${def;saxon94};9.4.0;9.3.0},\
+  net.sf.saxon.*;version=${if;${def;saxon95};9.5.0;${if;${def;saxon94};9.4.0;9.3.0}},\
   javax.crypto.*,\
   javax.xml.*,\
   org.apache.commons.httpclient.*,\

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>net.sf.saxon</groupId>
       <artifactId>Saxon-HE</artifactId>
-      <version>9.4.0.7</version>
+      <version>@saxon-version@</version>
     </dependency>
 
     <!-- No need to specify commons-logging or commons-codec - they're transitive dependencies of httpclient -->


### PR DESCRIPTION
Here's an attempt to re-instate the Maven uploads. You [wrote](http://markmail.org/message/jgd7ohxu3naeukj7):

> my attempts to introduce the Saxon version number to the artifact names were apparently unsuccessful

This PR sets the POM version to the value of the property `mvn-version` which in turn is based on `saxon-version`. It results in artifact file names like `xmlcalabash-1.0.12a-94`. Is that OK ?

Note that I also included a fix to the bnd config file (used for the OSGi metadata generation); it now looks at the `saxon95` property to declare the correct version of the Saxon dependency.
