### PR TITLE
Fix warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,17 +209,23 @@
               <execution>
                 <id>default-compile</id>
                 <configuration>
-                  <compilerArguments>
-                    <bootclasspath>${bootclasspath.compile}</bootclasspath>
-                  </compilerArguments>
+                  <compilerArgs>
+                    <arg>-Xlint</arg>
+                    <arg>-Xlint:-serial</arg>
+                    <arg>-bootclasspath</arg>
+                    <arg>${bootclasspath.compile}</arg>
+                  </compilerArgs>
                 </configuration>
               </execution>
               <execution>
                 <id>default-testCompile</id>
                 <configuration>
-                  <compilerArguments>
-                    <bootclasspath>${bootclasspath.testCompile}</bootclasspath>
-                  </compilerArguments>
+                  <compilerArgs>
+                    <arg>-Xlint</arg>
+                    <arg>-Xlint:-serial</arg>
+                    <arg>-bootclasspath</arg>
+                    <arg>${bootclasspath.testCompile}</arg>
+                  </compilerArgs>
                 </configuration>
               </execution>
             </executions>
@@ -265,19 +271,21 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
 
+        <configuration>
+          <showWarnings>true</showWarnings>
+          <showDeprecation>true</showDeprecation>
+          <source>1.6</source>
+          <target>1.6</target>
+          <compilerArgs>
+            <arg>-Xlint</arg>
+            <arg>-Xlint:-serial</arg>
+          </compilerArgs>
+        </configuration>
+
         <executions>
           <execution>
             <id>default-compile</id>
             <configuration>
-              <showWarnings>true</showWarnings>
-              <showDeprecation>true</showDeprecation>
-              <compilerArgument>-Xlint:-serial</compilerArgument>
-              <compilerArguments>
-                <Xlint/>
-              </compilerArguments>
-              <source>1.6</source>
-              <target>1.6</target>
-
               <excludes>
                 <!-- Requires Delta XML Core (not available through Maven) -->
                 <exclude>com/xmlcalabash/extensions/DeltaXML.java</exclude>
@@ -302,16 +310,6 @@
 
           <execution>
             <id>default-testCompile</id>
-            <configuration>
-              <showWarnings>true</showWarnings>
-              <showDeprecation>true</showDeprecation>
-              <compilerArgument>-Xlint:-serial</compilerArgument>
-              <compilerArguments>
-                <Xlint/>
-              </compilerArguments>
-              <source>1.6</source>
-              <target>1.6</target>
-            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/src/com/xmlcalabash/core/XProcConfiguration.java
+++ b/src/com/xmlcalabash/core/XProcConfiguration.java
@@ -474,8 +474,8 @@ public class XProcConfiguration {
         }
 
 		try {
-			Constructor constructor = Class.forName(className).getConstructor(XProcRuntime.class, XAtomicStep.class);
-			return (XProcStep) constructor.newInstance(runtime,step);
+			Constructor<? extends XProcStep> constructor = Class.forName(className).asSubclass(XProcStep.class).getConstructor(XProcRuntime.class, XAtomicStep.class);
+			return constructor.newInstance(runtime,step);
 		} catch (NoSuchMethodException nsme) {
 			throw new UnsupportedOperationException("No such method: " + className, nsme);
 		} catch (ClassNotFoundException cfne) {

--- a/src/com/xmlcalabash/core/XProcConfiguration.java
+++ b/src/com/xmlcalabash/core/XProcConfiguration.java
@@ -83,7 +83,7 @@ public class XProcConfiguration {
     public String entityResolver = null;
     public String uriResolver = null;
     public String errorListener = null;
-    public Hashtable<QName,Class> implementations = new Hashtable<QName,Class> ();
+    public Hashtable<QName,Class<?>> implementations = new Hashtable<QName,Class<?>> ();
     public Hashtable<String,String> serializationOptions = new Hashtable<String,String>();
     public LogOptions logOpt = LogOptions.WRAPPED;
     public Vector<String> extensionFunctions = new Vector<String>();
@@ -444,7 +444,7 @@ public class XProcConfiguration {
 
 	public boolean isStepAvailable(QName type) {
         if (implementations.containsKey(type)) {
-            Class klass = implementations.get(type);
+            Class<?> klass = implementations.get(type);
             try {
                 Method method = klass.getMethod("isAvailable");
                 Boolean available = (Boolean) method.invoke(null);
@@ -462,7 +462,7 @@ public class XProcConfiguration {
 	}
 
 	public XProcStep newStep(XProcRuntime runtime,XAtomicStep step){
-        Class klass = implementations.get(step.getType());
+        Class<?> klass = implementations.get(step.getType());
         if (klass == null) {
             throw new XProcException("Misconfigured. No 'class' in configuration for " + step.getType());
         }
@@ -828,7 +828,7 @@ public class XProcConfiguration {
         for (String tname : nameStr.split("\\s+")) {
             QName name = new QName(tname,node);
             try {
-                Class klass = Class.forName(value);
+                Class<?> klass = Class.forName(value);
                 implementations.put(name, klass);
             } catch (ClassNotFoundException e) {
                 // nop

--- a/src/com/xmlcalabash/core/XProcRuntime.java
+++ b/src/com/xmlcalabash/core/XProcRuntime.java
@@ -177,8 +177,8 @@ public class XProcRuntime {
         if (config.xprocConfigurer != null) {
             try {
                 String className = config.xprocConfigurer;
-                Constructor constructor = Class.forName(className).getConstructor(XProcRuntime.class);
-                configurer = (XProcConfigurer) constructor.newInstance(this);
+                Constructor<? extends XProcConfigurer> constructor = Class.forName(className).asSubclass(XProcConfigurer.class).getConstructor(XProcRuntime.class);
+                configurer = constructor.newInstance(this);
             } catch (Exception e) {
                 throw new XProcException(e);
             }
@@ -212,14 +212,14 @@ public class XProcRuntime {
 
         try {
             if (config.uriResolver != null) {
-                uriResolver.setUnderlyingURIResolver((URIResolver) Class.forName(config.uriResolver).newInstance());
+                uriResolver.setUnderlyingURIResolver(Class.forName(config.uriResolver).asSubclass(URIResolver.class).newInstance());
             }
             if (config.entityResolver != null) {
-                uriResolver.setUnderlyingEntityResolver((EntityResolver) Class.forName(config.entityResolver).newInstance());
+                uriResolver.setUnderlyingEntityResolver(Class.forName(config.entityResolver).asSubclass(EntityResolver.class).newInstance());
             }
 
             if (config.errorListener != null) {
-                msgListener = (XProcMessageListener) Class.forName(config.errorListener).newInstance();
+                msgListener = Class.forName(config.errorListener).asSubclass(XProcMessageListener.class).newInstance();
             } else {
                 msgListener = new DefaultXProcMessageListener();
             }

--- a/src/com/xmlcalabash/drivers/CalabashTask.java
+++ b/src/com/xmlcalabash/drivers/CalabashTask.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Vector;
+import javax.xml.transform.URIResolver;
 
 import com.xmlcalabash.util.Input.Type;
 import com.xmlcalabash.util.UserArgs;
@@ -47,6 +48,7 @@ import org.apache.tools.ant.types.resources.FileResource;
 import org.apache.tools.ant.types.resources.Resources;
 import org.apache.tools.ant.types.resources.Union;
 import org.apache.tools.ant.util.FileNameMapper;
+import org.xml.sax.EntityResolver;
 
 import static com.xmlcalabash.util.Input.Type.DATA;
 import static com.xmlcalabash.util.Input.Type.XML;
@@ -340,7 +342,7 @@ public class CalabashTask extends MatchingTask {
             handleError("The pipeline element must be specified with at most one nested resource.");
         }
 
-        setPipeline((Resource) pipeline.iterator().next());
+        setPipeline(pipeline.iterator().next());
     }
 
     /**
@@ -732,7 +734,7 @@ public class CalabashTask extends MatchingTask {
             handleError("The profile element must be specified with at most one nested resource.");
         }
 
-        setProfileFile((Resource) profile.iterator().next());
+        setProfileFile(profile.iterator().next());
     }
 
     /**
@@ -780,7 +782,7 @@ public class CalabashTask extends MatchingTask {
             handleError("The saxonConfig element must be specified with at most one nested resource.");
         }
 
-        setSaxonConfigFile((Resource) saxonConfig.iterator().next());
+        setSaxonConfigFile(saxonConfig.iterator().next());
     }
 
     /**
@@ -841,7 +843,7 @@ public class CalabashTask extends MatchingTask {
             handleError("The config element must be specified with at most one nested resource.");
         }
 
-        setConfigFile((Resource) config.iterator().next());
+        setConfigFile(config.iterator().next());
     }
 
     /**
@@ -862,7 +864,7 @@ public class CalabashTask extends MatchingTask {
      *
      * @param entityResolver the resolver class for entity resolution
      */
-    public void setEntityResolver(Class entityResolver) {
+    public void setEntityResolver(Class<? extends EntityResolver> entityResolver) {
         try {
             userArgs.setEntityResolverClass(entityResolver.getName());
         } catch (Exception e) {
@@ -875,7 +877,7 @@ public class CalabashTask extends MatchingTask {
      *
      * @param uriResolver the resolver class for URI resolution
      */
-    public void setURIResolver(Class uriResolver) {
+    public void setURIResolver(Class<? extends URIResolver> uriResolver) {
         try {
             userArgs.setUriResolverClass(uriResolver.getName());
         } catch (Exception e) {
@@ -895,8 +897,8 @@ public class CalabashTask extends MatchingTask {
         }
 
         try {
-            for (Iterator iterator = libraries.iterator(); iterator.hasNext(); ) {
-                Resource library = (Resource) iterator.next();
+            for (Iterator<Resource> iterator = libraries.iterator(); iterator.hasNext(); ) {
+                Resource library = iterator.next();
                 userArgs.addLibrary(library.getInputStream(), library.toString());
             }
         } catch (Exception e) {
@@ -1262,8 +1264,8 @@ public class CalabashTask extends MatchingTask {
         try {
             for (String port : outputResources.keySet()) {
                 Union resources = outputResources.get(port);
-                for (Iterator iterator = resources.iterator(); iterator.hasNext(); ) {
-                    Resource resource = (Resource) iterator.next();
+                for (Iterator<Resource> iterator = resources.iterator(); iterator.hasNext(); ) {
+                    Resource resource = iterator.next();
                     userArgs.addOutput(port, resource.getOutputStream());
                 }
             }

--- a/src/com/xmlcalabash/extensions/MetadataExtractor.java
+++ b/src/com/xmlcalabash/extensions/MetadataExtractor.java
@@ -171,7 +171,7 @@ public class MetadataExtractor extends DefaultStep {
 
             while (!imageFailed && (width == -1 || depth == -1)) {
                 try {
-                    java.lang.Thread.currentThread().sleep(50);
+                    Thread.sleep(50);
                 } catch (Exception e) {
                     // nop;
                 }

--- a/src/com/xmlcalabash/extensions/MetadataExtractor.java
+++ b/src/com/xmlcalabash/extensions/MetadataExtractor.java
@@ -89,13 +89,13 @@ public class MetadataExtractor extends DefaultStep {
             tree.startContent();
 
             // iterate through metadata directories
-            Iterator directories = metadata.getDirectories().iterator();
+            Iterator<Directory> directories = metadata.getDirectories().iterator();
             while (directories.hasNext()) {
-                Directory directory = (Directory) directories.next();
+                Directory directory = directories.next();
                 String dir = directory.getName();
-                Iterator tags = directory.getTags().iterator();
+                Iterator<Tag> tags = directory.getTags().iterator();
                 while (tags.hasNext()) {
-                    Tag tag = (Tag) tags.next();
+                    Tag tag = tags.next();
 
                     tree.addStartElement(c_tag);
                     tree.addAttribute(_dir, dir);

--- a/src/com/xmlcalabash/extensions/Zip.java
+++ b/src/com/xmlcalabash/extensions/Zip.java
@@ -297,9 +297,9 @@ public class Zip extends DefaultStep {
 
         try {
             if (inZip != null) {
-                Enumeration zenum = inZip.entries();
+                Enumeration<? extends ZipEntry> zenum = inZip.entries();
                 while (zenum.hasMoreElements()) {
-                    ZipEntry entry = (ZipEntry) zenum.nextElement();
+                    ZipEntry entry = zenum.nextElement();
                     String name = entry.getName();
 
                     boolean skip = srcManifest.containsKey(name);
@@ -405,9 +405,9 @@ public class Zip extends DefaultStep {
     public void delete(ZipFile inZip, ZipOutputStream outZip) {
         try {
             if (inZip != null) {
-                Enumeration zenum = inZip.entries();
+                Enumeration<? extends ZipEntry> zenum = inZip.entries();
                 while (zenum.hasMoreElements()) {
-                    ZipEntry entry = (ZipEntry) zenum.nextElement();
+                    ZipEntry entry = zenum.nextElement();
                     String name = entry.getName();
                     boolean delete = false;
 

--- a/src/com/xmlcalabash/functions/BaseURI.java
+++ b/src/com/xmlcalabash/functions/BaseURI.java
@@ -78,7 +78,7 @@ public class BaseURI extends XProcExtensionFunctionDefinition {
     }
 
     private class BaseURICall extends ExtensionFunctionCall {
-        public SequenceIterator call(SequenceIterator[] arguments, XPathContext context) throws XPathException {
+        public SequenceIterator<?> call(SequenceIterator<?>[] arguments, XPathContext context) throws XPathException {
             String baseURI = null;
 
             XProcRuntime runtime = tl_runtime.get();
@@ -90,7 +90,7 @@ public class BaseURI extends XProcExtensionFunctionDefinition {
             }
 
             if (arguments.length > 0) {
-                SequenceIterator iter = arguments[0];
+                SequenceIterator<?> iter = arguments[0];
                 NodeInfo item = (NodeInfo) iter.next();
                 baseURI = item.getBaseURI();
             } else {

--- a/src/com/xmlcalabash/functions/Cwd.java
+++ b/src/com/xmlcalabash/functions/Cwd.java
@@ -74,7 +74,7 @@ public class Cwd extends XProcExtensionFunctionDefinition {
     }
 
     private class CwdCall extends ExtensionFunctionCall {
-        public SequenceIterator call(SequenceIterator[] arguments, XPathContext context) throws XPathException {
+        public SequenceIterator<?> call(SequenceIterator<?>[] arguments, XPathContext context) throws XPathException {
 
             XProcRuntime runtime = tl_runtime.get();
             XStep step = runtime.getXProcData().getStep();

--- a/src/com/xmlcalabash/functions/IterationPosition.java
+++ b/src/com/xmlcalabash/functions/IterationPosition.java
@@ -74,7 +74,7 @@ public class IterationPosition extends XProcExtensionFunctionDefinition {
     }
 
     private class IterationPositionCall extends ExtensionFunctionCall {
-        public SequenceIterator call(SequenceIterator[] arguments, XPathContext context) throws XPathException {
+        public SequenceIterator<?> call(SequenceIterator<?>[] arguments, XPathContext context) throws XPathException {
             XProcRuntime runtime = tl_runtime.get();
             XProcData data = runtime.getXProcData();
             XStep step = data.getStep();

--- a/src/com/xmlcalabash/functions/IterationSize.java
+++ b/src/com/xmlcalabash/functions/IterationSize.java
@@ -73,7 +73,7 @@ public class IterationSize extends XProcExtensionFunctionDefinition {
     }
 
     private class IterationPositionCall extends ExtensionFunctionCall {
-        public SequenceIterator call(SequenceIterator[] arguments, XPathContext context) throws XPathException {
+        public SequenceIterator<?> call(SequenceIterator<?>[] arguments, XPathContext context) throws XPathException {
             XProcRuntime runtime = tl_runtime.get();
             XStep step = runtime.getXProcData().getStep();
             // FIXME: this can't be the best way to do this...

--- a/src/com/xmlcalabash/functions/ResolveURI.java
+++ b/src/com/xmlcalabash/functions/ResolveURI.java
@@ -82,8 +82,8 @@ public class ResolveURI extends XProcExtensionFunctionDefinition {
     }
 
     private class ResolveURICall extends ExtensionFunctionCall {
-        public SequenceIterator call(SequenceIterator[] arguments, XPathContext context) throws XPathException {
-            SequenceIterator iter = arguments[0];
+        public SequenceIterator<?> call(SequenceIterator<?>[] arguments, XPathContext context) throws XPathException {
+            SequenceIterator<?> iter = arguments[0];
             String relativeURI = iter.next().getStringValue();
 
             XProcRuntime runtime = tl_runtime.get();
@@ -102,7 +102,7 @@ public class ResolveURI extends XProcExtensionFunctionDefinition {
                 baseURI = runtime.getStaticBaseURI().toASCIIString();
                 try {
                     // FIXME: TinyDocumentImpl? Surely we can do better than that!
-                    Item item = context.getContextItem();
+                    Item<?> item = context.getContextItem();
                     baseURI = ((TinyDocumentImpl) item).getBaseURI();
                 } catch (Exception e) {
                     // nop

--- a/src/com/xmlcalabash/functions/StepAvailable.java
+++ b/src/com/xmlcalabash/functions/StepAvailable.java
@@ -84,7 +84,7 @@ public class StepAvailable extends XProcExtensionFunctionDefinition {
             staticContext = context;
         }
 
-        public SequenceIterator call(SequenceIterator[] arguments, XPathContext context) throws XPathException {
+        public SequenceIterator<?> call(SequenceIterator<?>[] arguments, XPathContext context) throws XPathException {
             StructuredQName stepName = null;
 
             XProcRuntime runtime = tl_runtime.get();
@@ -96,7 +96,7 @@ public class StepAvailable extends XProcExtensionFunctionDefinition {
             }
 
             try {
-                SequenceIterator iter = arguments[0];
+                SequenceIterator<?> iter = arguments[0];
                 String lexicalQName = iter.next().getStringValue();
                 stepName = StructuredQName.fromLexicalQName(
                      lexicalQName,

--- a/src/com/xmlcalabash/functions/SystemProperty.java
+++ b/src/com/xmlcalabash/functions/SystemProperty.java
@@ -63,7 +63,7 @@ public class SystemProperty extends XProcExtensionFunctionDefinition {
              staticContext = context;
          }
 
-         public SequenceIterator call(SequenceIterator[] arguments, XPathContext context) throws XPathException {
+         public SequenceIterator<?> call(SequenceIterator<?>[] arguments, XPathContext context) throws XPathException {
              StructuredQName propertyName = null;
 
              XProcRuntime runtime = tl_runtime.get();
@@ -75,7 +75,7 @@ public class SystemProperty extends XProcExtensionFunctionDefinition {
              }
 
              try {
-                 SequenceIterator iter = arguments[0];
+                 SequenceIterator<?> iter = arguments[0];
                  String lexicalQName = iter.next().getStringValue();
                  propertyName = StructuredQName.fromLexicalQName(
                       lexicalQName,

--- a/src/com/xmlcalabash/functions/ValueAvailable.java
+++ b/src/com/xmlcalabash/functions/ValueAvailable.java
@@ -85,7 +85,7 @@ public class ValueAvailable extends XProcExtensionFunctionDefinition {
             staticContext = context;
         }
 
-        public SequenceIterator call(SequenceIterator[] arguments, XPathContext context) throws XPathException {
+        public SequenceIterator<?> call(SequenceIterator<?>[] arguments, XPathContext context) throws XPathException {
             StructuredQName sVarName = null;
 
             XProcRuntime runtime = tl_runtime.get();
@@ -97,7 +97,7 @@ public class ValueAvailable extends XProcExtensionFunctionDefinition {
             }
 
             try {
-                SequenceIterator iter = arguments[0];
+                SequenceIterator<?> iter = arguments[0];
                 String lexicalQName = iter.next().getStringValue();
                 sVarName = StructuredQName.fromLexicalQName(
                      lexicalQName,
@@ -112,9 +112,9 @@ public class ValueAvailable extends XProcExtensionFunctionDefinition {
             boolean failIfUnknown = true;
 
             if (arguments.length > 1) {
-                SequenceIterator iter = arguments[1];
+                SequenceIterator<?> iter = arguments[1];
                 iter = iter.next().getTypedValue();
-                Item item = iter.next();
+                Item<?> item = iter.next();
                 failIfUnknown = ((BooleanValue) item).effectiveBooleanValue();
             }
 

--- a/src/com/xmlcalabash/functions/VersionAvailable.java
+++ b/src/com/xmlcalabash/functions/VersionAvailable.java
@@ -74,8 +74,8 @@ public class VersionAvailable extends XProcExtensionFunctionDefinition {
     }
 
     private class SystemPropertyCall extends ExtensionFunctionCall {
-        public SequenceIterator call(SequenceIterator[] arguments, XPathContext context) throws XPathException {
-            SequenceIterator iter = arguments[0];
+        public SequenceIterator<?> call(SequenceIterator<?>[] arguments, XPathContext context) throws XPathException {
+            SequenceIterator<?> iter = arguments[0];
 
             XProcRuntime runtime = tl_runtime.get();
             XStep step = runtime.getXProcData().getStep();

--- a/src/com/xmlcalabash/functions/XPathVersionAvailable.java
+++ b/src/com/xmlcalabash/functions/XPathVersionAvailable.java
@@ -74,8 +74,8 @@ public class XPathVersionAvailable extends XProcExtensionFunctionDefinition {
     }
 
     private class SystemPropertyCall extends ExtensionFunctionCall {
-        public SequenceIterator call(SequenceIterator[] arguments, XPathContext context) throws XPathException {
-            SequenceIterator iter = arguments[0];
+        public SequenceIterator<?> call(SequenceIterator<?>[] arguments, XPathContext context) throws XPathException {
+            SequenceIterator<?> iter = arguments[0];
 
             XProcRuntime runtime = tl_runtime.get();
             XStep step = runtime.getXProcData().getStep();

--- a/src/com/xmlcalabash/io/Select.java
+++ b/src/com/xmlcalabash/io/Select.java
@@ -95,9 +95,9 @@ public class Select implements ReadablePipe {
 
                 selector.setContextItem(doc);
 
-                Iterator iter = selector.iterator();
+                Iterator<XdmItem> iter = selector.iterator();
                 while (iter.hasNext()) {
-                    XdmItem item = (XdmItem) iter.next();
+                    XdmItem item = iter.next();
                     XdmNode node = null;
                     try {
                         node = (XdmNode) item;

--- a/src/com/xmlcalabash/library/SplitSequence.java
+++ b/src/com/xmlcalabash/library/SplitSequence.java
@@ -97,7 +97,7 @@ public class SplitSequence extends DefaultStep {
             XdmNode doc = source.read();
             pos++;
 
-            Item item = null;
+            Item<?> item = null;
 
             try {
                 XPathCompiler xcomp = runtime.getProcessor().newXPathCompiler();
@@ -140,7 +140,7 @@ public class SplitSequence extends DefaultStep {
                 // Then evaluate the expression by calling iterate() on the
                 // net.sf.saxon.sxpath.XPathExpression object.
 
-                SequenceIterator results = xexpr.iterate(xdc);
+                SequenceIterator<?> results = xexpr.iterate(xdc);
                 // FIXME: What if the expression returns a sequence?
                 item = results.next();
             } catch (XPathException xe) {

--- a/src/com/xmlcalabash/library/Template.java
+++ b/src/com/xmlcalabash/library/Template.java
@@ -195,9 +195,9 @@ public class Template extends DefaultStep implements ProcessMatchingNodes {
         if (parent.getNodeKind() == XdmNodeKind.ELEMENT) {
             NodeInfo inode = parent.getUnderlyingNode();
             InscopeNamespaceResolver inscopeNS = new InscopeNamespaceResolver(inode);
-            Iterator<String> prefixes = inscopeNS.iteratePrefixes();
+            Iterator<?> prefixes = inscopeNS.iteratePrefixes();
             while (prefixes.hasNext()) {
-                String nspfx = prefixes.next();
+                String nspfx = (String)prefixes.next();
                 String nsuri = inscopeNS.getURIForPrefix(nspfx, true);
                 nsbindings.put(nspfx,nsuri);
             }

--- a/src/com/xmlcalabash/library/ValidateWithXSD.java
+++ b/src/com/xmlcalabash/library/ValidateWithXSD.java
@@ -75,7 +75,7 @@ public class ValidateWithXSD extends DefaultStep {
     private static final QName _line = new QName("line");
     private static final QName _column = new QName("column");
 
-    private static final Class [] paramTypes = new Class [] {};
+    private static final Class<?>[] paramTypes = new Class<?>[] {};
     private ReadablePipe source = null;
     private ReadablePipe schemas = null;
     private WritablePipe result = null;

--- a/src/com/xmlcalabash/library/WrapSequence.java
+++ b/src/com/xmlcalabash/library/WrapSequence.java
@@ -136,7 +136,7 @@ public class WrapSequence extends DefaultStep {
             XdmNode node = source.read();
             pos++;
 
-            Item item = null;
+            Item<?> item = null;
 
             try {
                 XPathCompiler xcomp = runtime.getProcessor().newXPathCompiler();
@@ -179,7 +179,7 @@ public class WrapSequence extends DefaultStep {
                 // Then evaluate the expression by calling iterate() on the
                 // net.sf.saxon.sxpath.XPathExpression object.
 
-                SequenceIterator results = xexpr.iterate(xdc);
+                SequenceIterator<?> results = xexpr.iterate(xdc);
                 item = results.next();
 
                 if (item == null) {

--- a/src/com/xmlcalabash/model/Parser.java
+++ b/src/com/xmlcalabash/model/Parser.java
@@ -1895,8 +1895,8 @@ public class Parser {
 
             // We think this will work because we know from the test above that we're not in Saxon HE.
             // It's a bit fragile, but I can't think of a better way.
-            Class pc = Class.forName("com.saxonica.config.ProfessionalConfiguration");
-            Class fc = Class.forName("net.sf.saxon.functions.FunctionLibrary");
+            Class<?> pc = Class.forName("com.saxonica.config.ProfessionalConfiguration");
+            Class<?> fc = Class.forName("net.sf.saxon.functions.FunctionLibrary");
             Method setBinder = pc.getMethod("setExtensionBinder", String.class, fc);
             setBinder.invoke(processor.getUnderlyingConfiguration(), "xmlcalabash" + importCount, fl);
             importCount++;

--- a/src/com/xmlcalabash/runtime/XAtomicStep.java
+++ b/src/com/xmlcalabash/runtime/XAtomicStep.java
@@ -605,9 +605,9 @@ public class XAtomicStep extends XStep {
                     NodeInfo inode = nsbinding.getNode().getUnderlyingNode();
                     NamePool pool = inode.getNamePool();
                     InscopeNamespaceResolver inscopeNS = new InscopeNamespaceResolver(inode);
-                    Iterator<String> pfxiter = inscopeNS.iteratePrefixes();
+                    Iterator<?> pfxiter = inscopeNS.iteratePrefixes();
                     while (pfxiter.hasNext()) {
-                        String nspfx = pfxiter.next();
+                        String nspfx = (String)pfxiter.next();
                         String nsuri = inscopeNS.getURIForPrefix(nspfx, "".equals(nspfx));
                         lclnsBindings.put(nspfx, nsuri);
                     }

--- a/src/com/xmlcalabash/runtime/XSelect.java
+++ b/src/com/xmlcalabash/runtime/XSelect.java
@@ -135,9 +135,9 @@ public class XSelect implements ReadablePipe {
 
                 selector.setContextItem(doc);
 
-                Iterator iter = selector.iterator();
+                Iterator<XdmItem> iter = selector.iterator();
                 while (iter.hasNext()) {
-                    XdmItem item = (XdmItem) iter.next();
+                    XdmItem item = iter.next();
                     XdmNode node = null;
                     try {
                         node = (XdmNode) item;

--- a/src/com/xmlcalabash/util/CollectionResolver.java
+++ b/src/com/xmlcalabash/util/CollectionResolver.java
@@ -3,6 +3,7 @@ package com.xmlcalabash.util;
 import net.sf.saxon.lib.CollectionURIResolver;
 import net.sf.saxon.trans.XPathException;
 import net.sf.saxon.expr.XPathContext;
+import net.sf.saxon.om.NodeInfo;
 import net.sf.saxon.om.SequenceIterator;
 import net.sf.saxon.om.Item;
 import net.sf.saxon.s9api.XdmNode;
@@ -34,14 +35,14 @@ public class CollectionResolver implements CollectionURIResolver {
         this.chainedResolver = chainedResolver;
     }
 
-    public SequenceIterator resolve(String href, String base, XPathContext context) throws XPathException {
+    public SequenceIterator<?> resolve(String href, String base, XPathContext context) throws XPathException {
         runtime.finest(null, null, "Collection: " + href + " (" + base + ")");
         if (href == null) {
-            Item[] array = new Item[docs.size()];
+            Item<?>[] array = new Item<?>[docs.size()];
             for (int pos = 0; pos < docs.size(); pos++) {
                 array[pos] = docs.get(pos).getUnderlyingNode();
             }
-            return new ArrayIterator(array);
+            return new ArrayIterator<Item<?>>(array);
         } else {
             try {
                 URI hrefuri;
@@ -53,11 +54,11 @@ public class CollectionResolver implements CollectionURIResolver {
                 }
                 Vector<XdmNode> docs = runtime.getCollection(hrefuri);
                 if (docs != null) {
-                    Item[] items = new Item[docs.size()];
+                    Item<?>[] items = new Item<?>[docs.size()];
                     for (int pos = 0; pos < docs.size(); pos++) {
                         items[pos] = docs.get(pos).getUnderlyingNode();
                     }
-                    return new ArrayIterator(items);
+                    return new ArrayIterator<Item<?>>(items);
                 }
             } catch (URISyntaxException use) {
                 runtime.finest(null, null, "URI Syntax exception resolving collection URI: " + href + " (" + base + ")");

--- a/src/com/xmlcalabash/util/DocumentSequenceIterator.java
+++ b/src/com/xmlcalabash/util/DocumentSequenceIterator.java
@@ -2,6 +2,7 @@ package com.xmlcalabash.util;
 
 import net.sf.saxon.expr.LastPositionFinder;
 import net.sf.saxon.om.Item;
+import net.sf.saxon.om.NodeInfo;
 import net.sf.saxon.om.SequenceIterator;
 import net.sf.saxon.trans.XPathException;
 
@@ -12,16 +13,16 @@ import net.sf.saxon.trans.XPathException;
  * Time: 4:35:36 PM
  * To change this template use File | Settings | File Templates.
  */
-public class DocumentSequenceIterator implements SequenceIterator, LastPositionFinder {
+public class DocumentSequenceIterator implements SequenceIterator<Item<NodeInfo>>, LastPositionFinder<Item<NodeInfo>> {
     int position = 0;
     int last = 0;
-    Item item = null;
+    Item<NodeInfo> item = null;
 
     public void setPosition(int position) {
         this.position = position;
     }
 
-    public void setItem(Item item) {
+    public void setItem(Item<NodeInfo> item) {
         this.item = item;
     }
 
@@ -29,11 +30,11 @@ public class DocumentSequenceIterator implements SequenceIterator, LastPositionF
         this.last = last;
     }
 
-    public Item next() throws XPathException {
+    public Item<NodeInfo> next() throws XPathException {
         throw new UnsupportedOperationException("Don't know what to do for next() on DocumentSequenceIterator");
     }
 
-    public Item current() {
+    public Item<NodeInfo> current() {
         return item;
     }
 
@@ -45,7 +46,7 @@ public class DocumentSequenceIterator implements SequenceIterator, LastPositionF
         // ???
     }
 
-    public SequenceIterator getAnother() throws XPathException {
+    public SequenceIterator<Item<NodeInfo>> getAnother() throws XPathException {
         throw new UnsupportedOperationException("Don't know what to do for getAnother() on DocumentSequenceIterator");
     }
 

--- a/src/com/xmlcalabash/util/JSONtoXML.java
+++ b/src/com/xmlcalabash/util/JSONtoXML.java
@@ -109,9 +109,9 @@ public class JSONtoXML {
 
     private static void buildJsonXPairs(TreeWriter tree, JSONObject jo) {
         try {
-            Iterator keys = jo.keys();
+            Iterator<String> keys = jo.keys();
             while (keys.hasNext()) {
-                String name = (String) keys.next();
+                String name = keys.next();
                 Object json = jo.get(name);
                 serializeJsonX(tree, json, name);
             }
@@ -196,9 +196,9 @@ public class JSONtoXML {
 
     private static void buildMarkLogicPairs(TreeWriter tree, JSONObject jo) {
         try {
-            Iterator keys = jo.keys();
+            Iterator<String> keys = jo.keys();
             while (keys.hasNext()) {
-                String name = (String) keys.next();
+                String name = keys.next();
                 Object json = jo.get(name);
                 serializeMarkLogic(tree, json, name);
             }
@@ -293,9 +293,9 @@ public class JSONtoXML {
 
     private static void buildJxmlPairs(TreeWriter tree, JSONObject jo) {
         try {
-            Iterator keys = jo.keys();
+            Iterator<String> keys = jo.keys();
             while (keys.hasNext()) {
-                String name = (String) keys.next();
+                String name = keys.next();
                 Object json = jo.get(name);
                 serializeJxml(tree, json, name);
             }
@@ -385,9 +385,9 @@ public class JSONtoXML {
 
     private static void buildMyPairs(TreeWriter tree, JSONObject jo, boolean usens) {
         try {
-            Iterator keys = jo.keys();
+            Iterator<String> keys = jo.keys();
             while (keys.hasNext()) {
-                String name = (String) keys.next();
+                String name = keys.next();
                 Object json = jo.get(name);
                 tree.addStartElement(usens ? c_pair : _pair);
                 tree.addAttribute(_name, name);

--- a/src/com/xmlcalabash/util/S9apiUtils.java
+++ b/src/com/xmlcalabash/util/S9apiUtils.java
@@ -239,9 +239,9 @@ public class S9apiUtils {
             }
 
             if (all) {
-                Iterator<String> pfxiter = inscopeNS.iteratePrefixes();
+                Iterator<?> pfxiter = inscopeNS.iteratePrefixes();
                 while (pfxiter.hasNext()) {
-                    String pfx = pfxiter.next();
+                    String pfx = (String)pfxiter.next();
                     boolean def = ("".equals(pfx));
                     excludeURIs.add(inscopeNS.getURIForPrefix(pfx,def));
                 }

--- a/src/com/xmlcalabash/util/XPointerScheme.java
+++ b/src/com/xmlcalabash/util/XPointerScheme.java
@@ -88,9 +88,9 @@ public class XPointerScheme {
         try {
             selector.setContextItem(doc);
 
-            Iterator iter = selector.iterator();
+            Iterator<XdmItem> iter = selector.iterator();
             while (iter.hasNext()) {
-                XdmItem item = (XdmItem) iter.next();
+                XdmItem item = iter.next();
                 XdmNode node = null;
                 try {
                     node = (XdmNode) item;

--- a/src/com/xmlcalabash/util/XProcNamespaceContext.java
+++ b/src/com/xmlcalabash/util/XProcNamespaceContext.java
@@ -78,7 +78,7 @@ public class XProcNamespaceContext {
         return nshash;
     }
     
-    public Iterator getPrefixes(String namespace) {
+    public Iterator<String> getPrefixes(String namespace) {
         Vector<String> pfxs = new Vector<String> ();
         for (String key : nshash.keySet()) {
             if (namespace.equals(nshash.get(key))) {
@@ -88,7 +88,7 @@ public class XProcNamespaceContext {
         return pfxs.iterator();
     }
 
-    public Iterator getPrefixes() {
+    public Iterator<String> getPrefixes() {
         return null;
     }
 

--- a/src/org/json/CookieList.java
+++ b/src/org/json/CookieList.java
@@ -70,11 +70,11 @@ public class CookieList {
      */
     public static String toString(JSONObject o) throws JSONException {
         boolean      b = false;
-        Iterator     keys = o.keys();
+        Iterator<String> keys = o.keys();
         String       s;
         StringBuffer sb = new StringBuffer();
         while (keys.hasNext()) {
-            s = keys.next().toString();
+            s = keys.next();
             if (!o.isNull(s)) {
                 if (b) {
                     sb.append(';');

--- a/src/org/json/HTTP.java
+++ b/src/org/json/HTTP.java
@@ -125,7 +125,7 @@ public class HTTP {
      *  information.
      */
     public static String toString(JSONObject o) throws JSONException {
-        Iterator     keys = o.keys();
+        Iterator<String> keys = o.keys();
         String       s;
         StringBuffer sb = new StringBuffer();
         if (o.has("Status-Code") && o.has("Reason-Phrase")) {
@@ -147,7 +147,7 @@ public class HTTP {
         }
         sb.append(CRLF);
         while (keys.hasNext()) {
-            s = keys.next().toString();
+            s = keys.next();
             if (!s.equals("HTTP-Version")      && !s.equals("Status-Code") &&
                     !s.equals("Reason-Phrase") && !s.equals("Method") &&
                     !s.equals("Request-URI")   && !o.isNull(s)) {

--- a/src/org/json/JSONArray.java
+++ b/src/org/json/JSONArray.java
@@ -162,10 +162,10 @@ public class JSONArray {
      * Construct a JSONArray from a Collection.
      * @param collection     A Collection.
      */
-    public JSONArray(Collection collection) {
+    public JSONArray(Collection<?> collection) {
 		this.myArrayList = new ArrayList<Object>();
 		if (collection != null) {
-			Iterator iter = collection.iterator();
+			Iterator<?> iter = collection.iterator();
 			while (iter.hasNext()) {
 			    Object o = iter.next();
                 this.myArrayList.add(JSONObject.wrap(o));  
@@ -576,7 +576,7 @@ public class JSONArray {
      * @param value A Collection value.
      * @return      this.
      */
-    public JSONArray put(Collection value) {
+    public JSONArray put(Collection<?> value) {
         put(new JSONArray(value));
         return this;
     }
@@ -627,7 +627,7 @@ public class JSONArray {
      * @param value A Map value.
      * @return      this.
      */
-    public JSONArray put(Map value) {
+    public JSONArray put(Map<?, ?> value) {
         put(new JSONObject(value));
         return this;
     }
@@ -670,7 +670,7 @@ public class JSONArray {
      * @throws JSONException If the index is negative or if the value is
      * not finite.
      */
-    public JSONArray put(int index, Collection value) throws JSONException {
+    public JSONArray put(int index, Collection<?> value) throws JSONException {
         put(index, new JSONArray(value));
         return this;
     }
@@ -731,7 +731,7 @@ public class JSONArray {
      * @throws JSONException If the index is negative or if the the value is
      *  an invalid number.
      */
-    public JSONArray put(int index, Map value) throws JSONException {
+    public JSONArray put(int index, Map<?, ?> value) throws JSONException {
         put(index, new JSONObject(value));
         return this;
     }

--- a/src/org/json/JSONML.java
+++ b/src/org/json/JSONML.java
@@ -306,7 +306,7 @@ public class JSONML {
     	int			 i;
     	JSONObject   jo;
     	String       k;
-	    Iterator     keys;
+	    Iterator<String> keys;
 	    int			 length;
     	StringBuffer sb = new StringBuffer();
 	    String       tagName;
@@ -329,7 +329,7 @@ public class JSONML {
 			
 	        keys = jo.keys();
 	        while (keys.hasNext()) {
-	            k = keys.next().toString();
+	            k = keys.next();
             	XML.noSpace(k);
 	            v = jo.optString(k);
 	            if (v != null) {
@@ -389,7 +389,7 @@ public class JSONML {
 	    int          i;
 	    JSONArray    ja;
 	    String       k;
-	    Iterator     keys;
+	    Iterator<String> keys;
 	    int          len;
 	    String       tagName;
 	    String       v;
@@ -409,7 +409,7 @@ public class JSONML {
 	
         keys = jo.keys();
         while (keys.hasNext()) {
-            k = keys.next().toString();
+            k = keys.next();
             if (!k.equals("tagName") && !k.equals("childNodes")) {
             	XML.noSpace(k);
 	            v = jo.optString(k);

--- a/src/org/json/JSONObject.java
+++ b/src/org/json/JSONObject.java
@@ -128,7 +128,7 @@ public class JSONObject {
     /**
      * The map where the JSONObject's properties are kept.
      */
-    private Map map;
+    private Map<String, Object> map;
 
 
     /**
@@ -144,7 +144,7 @@ public class JSONObject {
      * Construct an empty JSONObject.
      */
     public JSONObject() {
-        this.map = new HashMap();
+        this.map = new HashMap<String, Object>();
     }
 
 
@@ -236,12 +236,10 @@ public class JSONObject {
      *  the JSONObject.
      * @throws JSONException 
      */
-    public JSONObject(Map map) {
-        this.map = new HashMap();
+    public JSONObject(Map<String, ?> map) {
+        this.map = new HashMap<String, Object>();
         if (map != null) {
-            Iterator i = map.entrySet().iterator();
-            while (i.hasNext()) {
-                Map.Entry e = (Map.Entry)i.next();
+            for (Map.Entry<String, ?> e : map.entrySet()) {
                 this.map.put(e.getKey(), wrap(e.getValue()));
             }
         }
@@ -286,7 +284,7 @@ public class JSONObject {
      */
     public JSONObject(Object object, String names[]) {
         this();
-        Class c = object.getClass();
+        Class<?> c = object.getClass();
         for (int i = 0; i < names.length; i += 1) {
             String name = names[i];
             try {
@@ -541,11 +539,11 @@ public class JSONObject {
         if (length == 0) {
             return null;
         }
-        Iterator i = jo.keys();
+        Iterator<String> i = jo.keys();
         String[] names = new String[length];
         int j = 0;
         while (i.hasNext()) {
-            names[j] = (String)i.next();
+            names[j] = i.next();
             j += 1;
         }
         return names;
@@ -561,7 +559,7 @@ public class JSONObject {
         if (object == null) {
             return null;
         }
-        Class klass = object.getClass();
+        Class<?> klass = object.getClass();
         Field[] fields = klass.getFields();
         int length = fields.length;
         if (length == 0) {
@@ -644,7 +642,7 @@ public class JSONObject {
      *
      * @return An iterator of the keys.
      */
-    public Iterator keys() {
+    public Iterator<String> keys() {
         return this.map.keySet().iterator();
     }
 
@@ -667,7 +665,7 @@ public class JSONObject {
      */
     public JSONArray names() {
         JSONArray ja = new JSONArray();
-        Iterator  keys = keys();
+        Iterator<String> keys = keys();
         while (keys.hasNext()) {
             ja.put(keys.next());
         }
@@ -900,7 +898,7 @@ public class JSONObject {
 
 
     private void populateMap(Object bean) {
-        Class klass = bean.getClass();
+        Class<?> klass = bean.getClass();
 
 // If klass is a System class then set includeSuperClass to false. 
 
@@ -967,7 +965,7 @@ public class JSONObject {
      * @return      this.
      * @throws JSONException
      */
-    public JSONObject put(String key, Collection value) throws JSONException {
+    public JSONObject put(String key, Collection<?> value) throws JSONException {
         put(key, new JSONArray(value));
         return this;
     }
@@ -1023,7 +1021,7 @@ public class JSONObject {
      * @return      this.
      * @throws JSONException
      */
-    public JSONObject put(String key, Map value) throws JSONException {
+    public JSONObject put(String key, Map<String, ?> value) throws JSONException {
         put(key, new JSONObject(value));
         return this;
     }
@@ -1173,8 +1171,8 @@ public class JSONObject {
      *
      * @return An iterator of the keys.
      */
-    public Iterator sortedKeys() {
-      return new TreeSet(this.map.keySet()).iterator();
+    public Iterator<String> sortedKeys() {
+      return new TreeSet<String>(this.map.keySet()).iterator();
     }
 
     /**
@@ -1289,14 +1287,14 @@ public class JSONObject {
      */
     public String toString() {
         try {
-            Iterator     keys = keys();
+            Iterator<String> keys = keys();
             StringBuffer sb = new StringBuffer("{");
 
             while (keys.hasNext()) {
                 if (sb.length() > 1) {
                     sb.append(',');
                 }
-                Object o = keys.next();
+                String o = keys.next();
                 sb.append(quote(o.toString()));
                 sb.append(':');
                 sb.append(valueToString(this.map.get(o)));
@@ -1345,13 +1343,13 @@ public class JSONObject {
         if (n == 0) {
             return "{}";
         }
-        Iterator     keys = sortedKeys();
+        Iterator<String> keys = sortedKeys();
         StringBuffer sb = new StringBuffer("{");
         int          newindent = indent + indentFactor;
-        Object       o;
+        String       o;
         if (n == 1) {
             o = keys.next();
-            sb.append(quote(o.toString()));
+            sb.append(quote(o));
             sb.append(": ");
             sb.append(valueToString(this.map.get(o), indentFactor,
                     indent));
@@ -1428,7 +1426,7 @@ public class JSONObject {
             return value.toString();
         }
         if (value instanceof Map) {
-            return new JSONObject((Map)value).toString();
+            return new JSONObject((Map<?, ?>)value).toString();
         }
         if (value instanceof Collection) {
             return new JSONArray((Collection)value).toString();
@@ -1481,7 +1479,7 @@ public class JSONObject {
             return ((JSONArray)value).toString(indentFactor, indent);
         }
         if (value instanceof Map) {
-            return new JSONObject((Map)value).toString(indentFactor, indent);
+            return new JSONObject((Map<?, ?>)value).toString(indentFactor, indent);
         }
         if (value instanceof Collection) {
             return new JSONArray((Collection)value).toString(indentFactor, indent);
@@ -1527,7 +1525,7 @@ public class JSONObject {
                  return new JSONArray(object);
              }
              if (object instanceof Map) {
-                 return new JSONObject((Map)object);
+                 return new JSONObject((Map<?, ?>)object);
              }
              Package objectPackage = object.getClass().getPackage();
              String objectPackageName = ( objectPackage != null ? objectPackage.getName() : "" );
@@ -1555,14 +1553,14 @@ public class JSONObject {
      public Writer write(Writer writer) throws JSONException {
         try {
             boolean  b = false;
-            Iterator keys = keys();
+            Iterator<String> keys = keys();
             writer.write('{');
 
             while (keys.hasNext()) {
                 if (b) {
                     writer.write(',');
                 }
-                Object k = keys.next();
+                String k = keys.next();
                 writer.write(quote(k.toString()));
                 writer.write(':');
                 Object v = this.map.get(k);

--- a/src/org/json/Test.java
+++ b/src/org/json/Test.java
@@ -16,7 +16,7 @@ public class Test {
      * @param args
      */
     public static void main(String args[]) {
-        Iterator it;
+        Iterator<String> it;
         JSONArray a;
         JSONObject j;
         JSONStringer jj;
@@ -456,7 +456,7 @@ public class Test {
             System.out.println("\nKeys: ");
             it = j.keys();
             while (it.hasNext()) {
-                s = (String)it.next();
+                s = it.next();
                 System.out.println(s + ": " + j.getString(s));
             }
 
@@ -487,8 +487,8 @@ public class Test {
             System.out.println(a.toString(4));
             System.out.println(JSONML.toString(a));
             
-            Collection c = null;
-            Map m = null;
+            Collection<?> c = null;
+            Map<?, ?> m = null;
             
             j = new JSONObject(m);
             a = new JSONArray(c);

--- a/src/org/json/XML.java
+++ b/src/org/json/XML.java
@@ -334,7 +334,7 @@ public class XML {
         JSONArray    ja;
         JSONObject   jo;
         String       k;
-        Iterator     keys;
+        Iterator<String> keys;
         int          len;
         String       s;
         Object       v;
@@ -353,7 +353,7 @@ public class XML {
             jo = (JSONObject)o;
             keys = jo.keys();
             while (keys.hasNext()) {
-                k = keys.next().toString();
+                k = keys.next();
                 v = jo.opt(k);
                 if (v == null) {
                 	v = "";


### PR DESCRIPTION
- Fix improper/sub-optimal generics usage
- Call static method directly, not through instance
- Improved specification of compiler arguments in pom.xml

After this change, the project builds without warnings even with `-Xlint -Xlint:-serial`.
