### PR TITLE
Mark the Saxon dependency as optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,9 @@
       <groupId>net.sf.saxon</groupId>
       <artifactId>Saxon-HE</artifactId>
       <version>9.4.0-9</version>
+      <!-- Marking this dependency as optional allows users to explicitly include
+           the correct Saxon version in the calling library. -->
+      <optional>true</optional>
     </dependency>
 
     <!-- No need to specify commons-logging or commons-codec - they're transitive dependencies of httpclient -->


### PR DESCRIPTION
Marking the dependency as `<optional>true</optional>` provides additional options to users of Saxon EE and other builds to explicitly declare their desired dependencies.
