### PR TITLE
allow xsl:params in Schematron

### DIFF
--- a/src/com/xmlcalabash/library/ValidateWithSCH.java
+++ b/src/com/xmlcalabash/library/ValidateWithSCH.java
@@ -151,6 +151,10 @@ public class ValidateWithSCH extends DefaultStep {
         compiler.setSchemaAware(schemaAware);
         exec = compiler.compile(compiledSchema.asSource());
         transformer = exec.load();
+	    for (QName name : params.keySet()) {
+             RuntimeValue v = params.get(name);
+             transformer.setParameter(name, new XdmAtomicValue(v.getString()));
+        }        
         transformer.setInitialContextNode(sourceXML);
         result = new XdmDestination();
         transformer.setDestination(result);


### PR DESCRIPTION
It was asked on [xproc-dev](http://lists.w3.org/Archives/Public/xproc-dev/2014Apr/0000.html) whether it was possible to pass parameters to Schematron `let` declarations. While this is not possible, I sketched a way how to allow foreign markup in Schematron and use `xsl:param` within the Schematron. 
While `xsl:*` may already be enabled by passing the parameter `allow-foreign = 'true'` to the `p:validate-with-schematron` step, the step’s parameters won’t currently propagate to the final pass, when the generated XSLT is applied to the document. 
So I suggest that we supply the same parameters also to the final pass.
The spec doesn’t seem to disallow this; it is kind of fuzzy on this whole parameter thing in `p:validate-with-schematron`: “The parameters port provides name/value pairs which correspond to 
Schematron external variables.”
