### PR TITLE
Close many potential resource leaks

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -107,16 +107,43 @@
 
   <target name="default" depends="jar"/>
 
-  <target name="init" depends="saxon-version">
+  <target name="init" depends="saxon-version,ant-version">
     <mkdir dir="${build.dir}"/>
     <property name="dist-version" value="${version}-${saxon-version-short}"/>
     <property name="install.dir" value="${dist.dir}/calabash-${dist-version}"/>
     <property name="docs.install.dir" value="${dist.dir}/calabash-${version}"/>
   </target>
 
+  <target name="ant-version">
+    <fail message="Please upgrade to Ant 1.7.0 or higher.">
+      <condition>
+        <not>
+          <antversion atleast="1.7.0"/>
+        </not>
+      </condition>
+    </fail>
+  </target>
+
   <target name="saxon95" if="saxon95">
     <property name="saxon-version-short" value="95"/>
-    <property name="saxon-version" value="9.5.1.1"/>
+    <!-- <property name="saxon-version" value="9.5.1.5"/> -->
+    <tempfile property="saxon-version-tmp-file"
+              destdir="${java.io.tmpdir}"
+              prefix="saxon.version"
+              suffix=".tmp"
+              deleteonexit="true"/>
+    <java classname="net.sf.saxon.Version"
+          classpathref="build.classpath"
+          output="${saxon-version-tmp-file}"/>
+    <loadfile property="saxon-version"
+              srcFile="${saxon-version-tmp-file}">
+      <filterchain>
+        <tokenfilter>
+          <stringtokenizer suppressdelims="true"/>
+          <containsregex pattern="\d+\.\d+\.\d+(\.\d+)?"/>
+        </tokenfilter>
+      </filterchain>
+    </loadfile>
   </target>
 
   <target name="saxon94" if="saxon94" unless="saxon95">
@@ -130,7 +157,9 @@
   </target>
 
   <target name="saxon-version" depends="saxon93,saxon94,saxon95">
+
     <echo>Currently using saxon ${saxon-version}</echo>
+    <echo>Currently using java ${java.version}</echo>
   </target>
 
   <target name="update-output">

--- a/src/com/xmlcalabash/core/XProcRuntime.java
+++ b/src/com/xmlcalabash/core/XProcRuntime.java
@@ -1033,7 +1033,8 @@ public class XProcRuntime {
                 serializer.setOutputProperty(Serializer.Property.INDENT, "yes");
 
                 OutputStream outstr = null;
-                switch (this.profile.getKind()) {
+                try {
+                    switch (this.profile.getKind()) {
                     case URI:
                         URI furi = URI.create(this.profile.getUri());
                         outstr = new FileOutputStream(new File(furi));
@@ -1045,12 +1046,14 @@ public class XProcRuntime {
 
                     default:
                         throw new UnsupportedOperationException(format("Unsupported profile kind '%s'", this.profile.getKind()));
-                }
+                    }
 
-                serializer.setOutputStream(outstr);
-                S9apiUtils.serialize(this, result.getXdmNode(), serializer);
-                if (!System.out.equals(outstr) && !System.err.equals(outstr)) {
-                    outstr.close();
+                    serializer.setOutputStream(outstr);
+                    S9apiUtils.serialize(this, result.getXdmNode(), serializer);
+                } finally {
+                    if (!System.out.equals(outstr) && !System.err.equals(outstr)) {
+                        outstr.close();
+                    }
                 }
 
                 profileWriter = new TreeWriter(this);

--- a/src/com/xmlcalabash/extensions/fileutils/Head.java
+++ b/src/com/xmlcalabash/extensions/fileutils/Head.java
@@ -77,40 +77,44 @@ public class Head extends DefaultStep {
                         throws IOException {
                     Reader rdr = new InputStreamReader(content);
                     BufferedReader brdr = new BufferedReader(rdr);
-                    String line = null;
-                    int count = 0;
+                    try {
+                        String line = null;
+                        int count = 0;
 
-                    if (maxCount >= 0) {
-                        line = brdr.readLine();
-                        while (line != null && count < maxCount) {
-                            tree.addStartElement(c_line);
-                            tree.startContent();
-                            tree.addText(line);
-                            tree.addEndElement();
-                            tree.addText("\n");
-                            count++;
+                        if (maxCount >= 0) {
                             line = brdr.readLine();
-                        }
-                    } else {
-                        line = "not null";
-                        while (line != null && count < negMaxCount) {
-                            count++;
-                            line = brdr.readLine();
-                        }
+                            while (line != null && count < maxCount) {
+                                tree.addStartElement(c_line);
+                                tree.startContent();
+                                tree.addText(line);
+                                tree.addEndElement();
+                                tree.addText("\n");
+                                count++;
+                                line = brdr.readLine();
+                            }
+                        } else {
+                            line = "not null";
+                            while (line != null && count < negMaxCount) {
+                                count++;
+                                line = brdr.readLine();
+                            }
 
-                        line = brdr.readLine();
-                        while (line != null) {
-                            tree.addStartElement(c_line);
-                            tree.startContent();
-                            tree.addText(line);
-                            tree.addEndElement();
-                            tree.addText("\n");
                             line = brdr.readLine();
+                            while (line != null) {
+                                tree.addStartElement(c_line);
+                                tree.startContent();
+                                tree.addText(line);
+                                tree.addEndElement();
+                                tree.addText("\n");
+                                line = brdr.readLine();
+                            }
                         }
+                    } finally {
+                        brdr.close();
+                        // BufferedReader.close() also closes the underlying 
+                        // reader, so this second call is unnecessary.
+                        // rdr.close();
                     }
-                    
-                    brdr.close();
-                    rdr.close();
                 }
             });
         } catch (FileNotFoundException fnfe) {

--- a/src/com/xmlcalabash/extensions/fileutils/Tail.java
+++ b/src/com/xmlcalabash/extensions/fileutils/Tail.java
@@ -80,26 +80,29 @@ public class Tail extends DefaultStep {
                     Reader rdr = new InputStreamReader(content);
                     BufferedReader brdr = new BufferedReader(rdr);
                     Vector<String> lines = new Vector<String> ();
-                    int count = 0;
-                    String line = brdr.readLine();
-                    while (line != null) {
-                        count++;
-                        lines.add(line);
+                    try {
+                        int count = 0;
+                        String line = brdr.readLine();
+                        while (line != null) {
+                            count++;
+                            lines.add(line);
 
-                        if (count > maxCount) {
-                            line = lines.remove(0);
-                            if (!tail) {
-                                tree.addStartElement(c_line);
-                                tree.startContent();
-                                tree.addText(line);
-                                tree.addEndElement();
-                                tree.addText("\n");
+                            if (count > maxCount) {
+                                line = lines.remove(0);
+                                if (!tail) {
+                                    tree.addStartElement(c_line);
+                                    tree.startContent();
+                                    tree.addText(line);
+                                    tree.addEndElement();
+                                    tree.addText("\n");
+                                }
                             }
-                        }
 
-                        line = brdr.readLine();
+                            line = brdr.readLine();
+                        }
+                    } finally {
+                        brdr.close();
                     }
-                    brdr.close();
 
                     if (tail) {
                         for (String lline : lines) {

--- a/src/com/xmlcalabash/io/PipeLogger.java
+++ b/src/com/xmlcalabash/io/PipeLogger.java
@@ -234,7 +234,7 @@ public class PipeLogger {
                 } catch (SaxonApiException sae) {
                     System.err.println("Logging failed: " + sae);
                 } finally {
-                    if (stream != null && !System.out.equals(stream) && !System.err.equals(stream)) {
+                    if (!System.err.equals(stream)) {
                         stream.close();
                     }
                 }

--- a/src/com/xmlcalabash/io/PipeLogger.java
+++ b/src/com/xmlcalabash/io/PipeLogger.java
@@ -224,17 +224,20 @@ public class PipeLogger {
                     System.err.println("Failed to create log: " + log.getHref());
                     stream = System.err;
                 }
-
-                serializer.setOutputStream(stream);
-
-                stream.println("<!-- Start of Calabash output " + log + " on " + dateTime() + " -->");
-
+                
                 try {
+                    serializer.setOutputStream(stream);
+
+                    stream.println("<!-- Start of Calabash output " + log + " on " + dateTime() + " -->");
+
                     S9apiUtils.serialize(runtime, node, serializer);
                 } catch (SaxonApiException sae) {
                     System.err.println("Logging failed: " + sae);
+                } finally {
+                    if (stream != null && !System.out.equals(stream) && !System.err.equals(stream)) {
+                        stream.close();
+                    }
                 }
-                stream.close();
                 break;
             default:
                 break;

--- a/src/com/xmlcalabash/library/Exec.java
+++ b/src/com/xmlcalabash/library/Exec.java
@@ -200,30 +200,32 @@ public class Exec extends DefaultStep {
 
                 OutputStream os = process.getOutputStream();
 
-                Serializer serializer = makeSerializer();
+                try {
+                    Serializer serializer = makeSerializer();
 
-                // FIXME: there must be a better way to print text descendants
-                String queryexpr = null;
-                if (sourceIsXML) {
-                    queryexpr = ".";
-                } else {
-                    queryexpr = "//text()";
-                    serializer.setOutputProperty(Serializer.Property.METHOD, "text");
-                    serializer.setOutputProperty(Serializer.Property.OMIT_XML_DECLARATION, "yes");
+                    // FIXME: there must be a better way to print text descendants
+                    String queryexpr = null;
+                    if (sourceIsXML) {
+                        queryexpr = ".";
+                    } else {
+                        queryexpr = "//text()";
+                        serializer.setOutputProperty(Serializer.Property.METHOD, "text");
+                        serializer.setOutputProperty(Serializer.Property.OMIT_XML_DECLARATION, "yes");
+                    }
+
+                    Processor qtproc = runtime.getProcessor();
+                    XQueryCompiler xqcomp = qtproc.newXQueryCompiler();
+                    xqcomp.setModuleURIResolver(runtime.getResolver());
+                    XQueryExecutable xqexec = xqcomp.compile(queryexpr);
+                    XQueryEvaluator xqeval = xqexec.load();
+                    xqeval.setContextItem(srcDoc);
+
+                    serializer.setOutputStream(os);
+                    xqeval.setDestination(serializer);
+                    xqeval.run();
+                } finally {
+                    os.close();
                 }
-
-                Processor qtproc = runtime.getProcessor();
-                XQueryCompiler xqcomp = qtproc.newXQueryCompiler();
-                xqcomp.setModuleURIResolver(runtime.getResolver());
-                XQueryExecutable xqexec = xqcomp.compile(queryexpr);
-                XQueryEvaluator xqeval = xqexec.load();
-                xqeval.setContextItem(srcDoc);
-
-                serializer.setOutputStream(os);
-                xqeval.setDestination(serializer);
-                xqeval.run();
-
-                os.close();
             } else {
                 OutputStream os = process.getOutputStream();
                 os.close();

--- a/src/com/xmlcalabash/library/Store.java
+++ b/src/com/xmlcalabash/library/Store.java
@@ -168,16 +168,17 @@ public class Store extends DefaultStep {
                 ByteArrayOutputStream baos;
                 baos = new ByteArrayOutputStream();
                 outstr = baos;
+                try {
+                    if (method == CompressionMethod.GZIP) {
+                        GZIPOutputStream gzout = new GZIPOutputStream(outstr);
+                        outstr = gzout;
+                    }
 
-                if (method == CompressionMethod.GZIP) {
-                    GZIPOutputStream gzout = new GZIPOutputStream(outstr);
-                    outstr = gzout;
+                    serializer.setOutputStream(outstr);
+                    S9apiUtils.serialize(runtime, doc, serializer);
+                } finally {
+                    outstr.close();
                 }
-
-                serializer.setOutputStream(outstr);
-                S9apiUtils.serialize(runtime, doc, serializer);
-                outstr.close();
-
                 returnData(baos);
                 return null;
             } else {
@@ -222,15 +223,16 @@ public class Store extends DefaultStep {
                 ByteArrayOutputStream baos = null;
                 baos = new ByteArrayOutputStream();
                 outstr = baos;
+                try {
+                    if (method == CompressionMethod.GZIP) {
+                        GZIPOutputStream gzout = new GZIPOutputStream(outstr);
+                        outstr = gzout;
+                    }
 
-                if (method == CompressionMethod.GZIP) {
-                    GZIPOutputStream gzout = new GZIPOutputStream(outstr);
-                    outstr = gzout;
+                    outstr.write(decoded);
+                } finally {
+                    outstr.close();
                 }
-
-                outstr.write(decoded);
-                outstr.close();
-
                 returnData(baos);
                 return null;
             } else {
@@ -267,15 +269,16 @@ public class Store extends DefaultStep {
                 ByteArrayOutputStream baos = null;
                 baos = new ByteArrayOutputStream();
                 outstr = baos;
+                try{
+                    if (method == CompressionMethod.GZIP) {
+                        GZIPOutputStream gzout = new GZIPOutputStream(outstr);
+                        outstr = gzout;
+                    }
 
-                if (method == CompressionMethod.GZIP) {
-                    GZIPOutputStream gzout = new GZIPOutputStream(outstr);
-                    outstr = gzout;
+                    outstr.write(text.getBytes());
+                } finally {
+                    outstr.close();
                 }
-
-                outstr.write(text.getBytes());
-                outstr.close();
-
                 returnData(baos);
                 return null;
             } else {
@@ -311,18 +314,20 @@ public class Store extends DefaultStep {
 
                 baos = new ByteArrayOutputStream();
                 outstr = baos;
+                try {
+                    if (method == CompressionMethod.GZIP) {
+                        GZIPOutputStream gzout = new GZIPOutputStream(outstr);
+                        outstr = gzout;
+                    }
 
-                if (method == CompressionMethod.GZIP) {
-                    GZIPOutputStream gzout = new GZIPOutputStream(outstr);
-                    outstr = gzout;
+                    PrintWriter writer = new PrintWriter(outstr);
+                    String json = XMLtoJSON.convert(doc);
+                    writer.print(json);
+                } finally {
+                    // no need to close both 
+                    // writer.close();
+                    outstr.close();
                 }
-
-                PrintWriter writer = new PrintWriter(outstr);
-                String json = XMLtoJSON.convert(doc);
-                writer.print(json);
-                writer.close();
-                outstr.close();
-
                 returnData(baos);
                 return null;
             } else {
@@ -337,7 +342,9 @@ public class Store extends DefaultStep {
                         PrintWriter writer = new PrintWriter(outstr);
                         String json = XMLtoJSON.convert(doc);
                         writer.print(json);
-                        writer.close();
+                        // No need to close writer here - the underlying 
+                        // outstr gets closed by the DataStore implementation 
+                        // writer.close();
                     }
                 });
             }

--- a/src/com/xmlcalabash/library/XInclude.java
+++ b/src/com/xmlcalabash/library/XInclude.java
@@ -321,11 +321,14 @@ public class XInclude extends DefaultStep implements ProcessMatchingNodes {
             data = xpointer.selectText(stream, (int) len);
         } else {
             rd = new BufferedReader(stream);
-            String line;
-            while ((line = rd.readLine()) != null) {
-                data += line + "\n";
+            try {
+                String line;
+                while ((line = rd.readLine()) != null) {
+                    data += line + "\n";
+                }
+            } finally {
+                rd.close();
             }
-            rd.close();
         }
 
         return data;

--- a/src/com/xmlcalabash/model/Parser.java
+++ b/src/com/xmlcalabash/model/Parser.java
@@ -80,9 +80,12 @@ public class Parser {
     }
 
     public DeclareStep loadPipeline(InputStream inputStream) throws SaxonApiException, IOException {
-        XdmNode doc = runtime.parse(new InputSource(inputStream));
-        inputStream.close();
-        return loadPipeline(doc);
+        try {
+            XdmNode doc = runtime.parse(new InputSource(inputStream));
+            return loadPipeline(doc);
+        } finally {
+            inputStream.close();
+        }
     }
 
     public DeclareStep loadPipeline(String uri) throws SaxonApiException {
@@ -159,10 +162,13 @@ public class Parser {
     }
 
     public PipelineLibrary loadLibrary(InputStream libraryInputStream) throws SaxonApiException, IOException {
-        XdmNode doc = runtime.parse(new InputSource(libraryInputStream));
-        libraryInputStream.close();
-        XdmNode root = S9apiUtils.getDocumentElement(doc);
-        return useLibrary(root);
+        try {
+            XdmNode doc = runtime.parse(new InputSource(libraryInputStream));
+            XdmNode root = S9apiUtils.getDocumentElement(doc);
+            return useLibrary(root);
+        } finally {
+            libraryInputStream.close();
+        }
     }
 
     public PipelineLibrary loadLibrary(String libraryURI) throws SaxonApiException {

--- a/src/com/xmlcalabash/runtime/XAtomicStep.java
+++ b/src/com/xmlcalabash/runtime/XAtomicStep.java
@@ -401,11 +401,13 @@ public class XAtomicStep extends XStep {
                 throw XProcException.dynamicError(19);
             }
 
+            
+        } finally {
             for (String port : outputs.keySet()) {
                 WritablePipe wpipe = outputs.get(port);
                 wpipe.close(); // Indicate we're done
             }
-        } finally {
+            
             runtime.finish(this);
             data.closeFrame();
         }

--- a/src/com/xmlcalabash/runtime/XForEach.java
+++ b/src/com/xmlcalabash/runtime/XForEach.java
@@ -149,6 +149,7 @@ public class XForEach extends XCompoundStep {
                 }
             }
 
+        } finally {
             for (String port : inputs.keySet()) {
                 if (port.startsWith("|")) {
                     String wport = port.substring(1);
@@ -156,7 +157,6 @@ public class XForEach extends XCompoundStep {
                     pipe.close(); // Indicate that we're done
                 }
             }
-        } finally {
             runtime.finish(this);
             data.closeFrame();
         }

--- a/src/com/xmlcalabash/runtime/XPipeline.java
+++ b/src/com/xmlcalabash/runtime/XPipeline.java
@@ -239,20 +239,23 @@ public class XPipeline extends XCompoundStep {
             if (port.startsWith("|")) {
                 String wport = port.substring(1);
                 WritablePipe pipe = outputs.get(wport);
-                for (ReadablePipe reader : inputs.get(port)) {
-                    // Check for the case where there are no documents, but a sequence is not allowed
-                    if (!reader.moreDocuments() && !pipe.writeSequence()) {
-                        throw XProcException.dynamicError(7);
-                    }
+                try {
+                    for (ReadablePipe reader : inputs.get(port)) {
+                        // Check for the case where there are no documents, but a sequence is not allowed
+                        if (!reader.moreDocuments() && !pipe.writeSequence()) {
+                            throw XProcException.dynamicError(7);
+                        }
 
 
-                    while (reader.moreDocuments()) {
-                        XdmNode doc = reader.read();
-                        pipe.write(doc);
-                        finest(step.getNode(), "Pipeline output copy from " + reader + " to " + pipe);
+                        while (reader.moreDocuments()) {
+                            XdmNode doc = reader.read();
+                            pipe.write(doc);
+                            finest(step.getNode(), "Pipeline output copy from " + reader + " to " + pipe);
+                        }
                     }
+                } finally {
+                    pipe.close(); // Indicate that we're done writing to it
                 }
-                pipe.close(); // Indicate that we're done writing to it
             }
         }
     }

--- a/src/com/xmlcalabash/runtime/XUntilUnchanged.java
+++ b/src/com/xmlcalabash/runtime/XUntilUnchanged.java
@@ -168,6 +168,7 @@ public class XUntilUnchanged extends XCompoundStep {
                 }
             }
 
+        } finally {
             for (String port : inputs.keySet()) {
                 if (port.startsWith("|")) {
                     String wport = port.substring(1);
@@ -175,7 +176,6 @@ public class XUntilUnchanged extends XCompoundStep {
                     pipe.close(); // Indicate that we're done
                 }
             }
-        } finally {
             runtime.finish(this);
             data.closeFrame();
         }

--- a/src/com/xmlcalabash/util/Base64.java
+++ b/src/com/xmlcalabash/util/Base64.java
@@ -1,5 +1,8 @@
 package com.xmlcalabash.util;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 /**
  * <p>Encodes and decodes to and from Base64 notation.</p>
  * <p>Homepage: <a href="http://iharder.net/base64">http://iharder.net/base64</a>.</p>
@@ -23,6 +26,9 @@ package com.xmlcalabash.util;
  * Change Log:
  * </p>
  * <ul>
+ *  <li> PATCH - Fixed potential NullPointerExceptions, and exceptions that
+ *      occur while closing a resource are now logged. All changes in this
+ *      patch are marked with PATCH in the code below.</li>
  *  <li>v2.2.2 - Fixed encodeFileToFile and decodeFileToFile to use the
  *   Base64.InputStream class to encode and decode on the fly which uses
  *   less memory than encoding/decoding an entire file into memory before writing.</li>
@@ -478,6 +484,24 @@ public class Base64
     }   // end encode3to4
 
 
+    
+    // -------------------------- BEGIN PATCH ---------------------------------
+    private static final Logger LOG = Logger.getLogger(Base64.class.getName());
+    /** 
+     * Closes the given Closeable, checking for null, 
+     * logging any Exception that occurs in the process. 
+     */
+    private static void closeOrLog(java.io.Closeable c) {
+        if (c != null) {
+            try {
+                c.close();
+            } catch (Exception e) {
+                LOG.log(Level.FINER, "Error closing resource", e);
+            }
+        }
+    }
+    // ------------------------- END PATCH --------------------------------
+    
 
     /**
      * Serializes an object and returns the Base64-encoded
@@ -556,10 +580,16 @@ public class Base64
         }   // end catch
         finally
         {
-            try{ oos.close();   } catch( Exception e ){}
-            try{ gzos.close();  } catch( Exception e ){}
-            try{ b64os.close(); } catch( Exception e ){}
-            try{ baos.close();  } catch( Exception e ){}
+            // ----------------------- BEGIN PATCH ----------------------------
+//            try{ oos.close();   } catch( Exception e ){}
+//            try{ gzos.close();  } catch( Exception e ){}
+//            try{ b64os.close(); } catch( Exception e ){}
+//            try{ baos.close();  } catch( Exception e ){}
+            closeOrLog(oos);
+            closeOrLog(gzos);
+            closeOrLog(b64os);
+            closeOrLog(baos);
+            // ----------------------- END PATCH -----------------------------
         }   // end finally
 
         // Return value according to relevant encoding.
@@ -676,7 +706,7 @@ public class Base64
                 gzos  = new java.util.zip.GZIPOutputStream( b64os );
 
                 gzos.write( source, off, len );
-                gzos.close();
+//                gzos.close();
             }   // end try
             catch( java.io.IOException e )
             {
@@ -685,9 +715,14 @@ public class Base64
             }   // end catch
             finally
             {
-                try{ gzos.close();  } catch( Exception e ){}
-                try{ b64os.close(); } catch( Exception e ){}
-                try{ baos.close();  } catch( Exception e ){}
+                // ----------------------- BEGIN PATCH ---------------------
+//                try{ gzos.close();  } catch( Exception e ){}
+//                try{ b64os.close(); } catch( Exception e ){}
+//                try{ baos.close();  } catch( Exception e ){}
+                closeOrLog(gzos);
+                closeOrLog(b64os);
+                closeOrLog(baos);
+                // ----------------------- END PATCH -----------------------
             }   // end finally
 
             // Return value according to relevant encoding.
@@ -984,9 +1019,14 @@ public class Base64
                 }   // end catch
                 finally
                 {
-                    try{ baos.close(); } catch( Exception e ){}
-                    try{ gzis.close(); } catch( Exception e ){}
-                    try{ bais.close(); } catch( Exception e ){}
+                    // ----------------------- BEGIN PATCH --------------------
+//                    try{ baos.close(); } catch( Exception e ){}
+//                    try{ gzis.close(); } catch( Exception e ){}
+//                    try{ bais.close(); } catch( Exception e ){}
+                    closeOrLog(baos);
+                    closeOrLog(gzis);
+                    closeOrLog(bais);
+                    // ----------------------- END PATCH -----------------------
                 }   // end finally
 
             }   // end if: gzipped
@@ -1034,8 +1074,12 @@ public class Base64
         }   // end catch
         finally
         {
-            try{ bais.close(); } catch( Exception e ){}
-            try{ ois.close();  } catch( Exception e ){}
+            // ----------------------- BEGIN PATCH --------------------
+//            try{ bais.close(); } catch( Exception e ){}
+//            try{ ois.close();  } catch( Exception e ){}
+            closeOrLog(bais);
+            closeOrLog(ois);
+            // ----------------------- END PATCH -----------------------
         }   // end finally
 
         return obj;
@@ -1070,7 +1114,10 @@ public class Base64
         }   // end catch: IOException
         finally
         {
-            try{ bos.close(); } catch( Exception e ){}
+            // ----------------------- BEGIN PATCH --------------------
+//            try{ bos.close(); } catch( Exception e ){}
+            closeOrLog(bos);
+            // ----------------------- END PATCH -----------------------
         }   // end finally
 
         return success;
@@ -1103,7 +1150,10 @@ public class Base64
         }   // end catch: IOException
         finally
         {
-                try{ bos.close(); } catch( Exception e ){}
+            // ----------------------- BEGIN PATCH --------------------
+//            try{ bos.close(); } catch( Exception e ){}
+            closeOrLog(bos);
+            // ----------------------- END PATCH -----------------------
         }   // end finally
 
         return success;
@@ -1161,7 +1211,10 @@ public class Base64
         }   // end catch: IOException
         finally
         {
-            try{ bis.close(); } catch( Exception e) {}
+            // ----------------------- BEGIN PATCH --------------------
+//            try{ bis.close(); } catch( Exception e) {}
+            closeOrLog(bis);
+            // ----------------------- END PATCH -----------------------
         }   // end finally
 
         return decodedData;
@@ -1209,7 +1262,10 @@ public class Base64
         }   // end catch: IOException
         finally
         {
-            try{ bis.close(); } catch( Exception e) {}
+            // ----------------------- BEGIN PATCH --------------------
+//            try{ bis.close(); } catch( Exception e) {}
+            closeOrLog(bis);
+            // ----------------------- END PATCH -----------------------
         }   // end finally
 
         return encodedData;
@@ -1246,8 +1302,12 @@ public class Base64
         } catch( java.io.IOException exc ){
             exc.printStackTrace();
         } finally{
-            try{ in.close();  } catch( Exception exc ){}
-            try{ out.close(); } catch( Exception exc ){}
+            // ----------------------- BEGIN PATCH --------------------
+//            try{ in.close();  } catch( Exception exc ){}
+//            try{ out.close(); } catch( Exception exc ){}
+            closeOrLog(in);
+            closeOrLog(out);
+            // ----------------------- END PATCH -----------------------
         }   // end finally
 
         return success;
@@ -1283,8 +1343,12 @@ public class Base64
         } catch( java.io.IOException exc ){
             exc.printStackTrace();
         } finally{
-            try{ in.close();  } catch( Exception exc ){}
-            try{ out.close(); } catch( Exception exc ){}
+            // ----------------------- BEGIN PATCH --------------------
+//            try{ in.close();  } catch( Exception exc ){}
+//            try{ out.close(); } catch( Exception exc ){}
+            closeOrLog(in);
+            closeOrLog(out);
+            // ----------------------- END PATCH -----------------------
         }   // end finally
 
         return success;

--- a/src/com/xmlcalabash/util/Closer.java
+++ b/src/com/xmlcalabash/util/Closer.java
@@ -1,0 +1,25 @@
+package com.xmlcalabash.util;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * Utility methods for closing objects that implement the Closeable interface.
+ */
+public final class Closer {
+
+    // prevent utility class from being created
+    private Closer() {
+    }
+
+    
+    /** 
+     * Closes the given Closeable, protecting against nulls.
+     */
+    public static void close(Closeable c) throws IOException {
+        if (c != null) {
+            c.close();
+        }
+    }
+    
+}

--- a/src/com/xmlcalabash/util/XPointerScheme.java
+++ b/src/com/xmlcalabash/util/XPointerScheme.java
@@ -131,68 +131,68 @@ public class XPointerScheme {
         BufferedReader rd = null;
 
         rd = new BufferedReader(stream);
-
-        String parts[] = select.split("\\s*;\\s*");
-        for (int pos = 1; pos < parts.length; pos++) {
-            // start at 1 because we want to skip the scheme
-            String check = parts[pos];
-            Matcher matcher = lengthRE.matcher(check);
-            if (contentLength >= 0 && matcher.matches()) {
-                int checklen = Integer.parseInt(matcher.group(1));
-                if (checklen != contentLength) {
-                    throw new IllegalArgumentException("Integrity check failed: " + checklen + " != " + contentLength);
+        try {
+            String parts[] = select.split("\\s*;\\s*");
+            for (int pos = 1; pos < parts.length; pos++) {
+                // start at 1 because we want to skip the scheme
+                String check = parts[pos];
+                Matcher matcher = lengthRE.matcher(check);
+                if (contentLength >= 0 && matcher.matches()) {
+                    int checklen = Integer.parseInt(matcher.group(1));
+                    if (checklen != contentLength) {
+                        throw new IllegalArgumentException("Integrity check failed: " + checklen + " != " + contentLength);
+                    }
                 }
             }
-        }
-        select = parts[0];
+            select = parts[0];
 
-        select = select.trim();
+            select = select.trim();
 
-        sp = -1;
-        ep = Long.MAX_VALUE;
-        cp = 0;
-        lp = 0;
+            sp = -1;
+            ep = Long.MAX_VALUE;
+            cp = 0;
+            lp = 0;
 
-        // FIXME: Isn't there a better way to do this?
-        Matcher matcher = rangeRE.matcher(select);
-        if (matcher.matches()) {
-            String r = matcher.group(1);
-            if (r != null && !"".equals(r)) {
-                sp = Integer.parseInt(r);
-            }
-            r = matcher.group(3);
-            if (r != null && !"".equals(r)) {
-                ep = Integer.parseInt(r);
-            }
-        }
-
-        if (select.startsWith("char=")) {
-            chars = true;
-        } else if (select.startsWith("line=")) {
-            chars = false;
-        } else {
-            throw new XProcException("Unparseable XPointer: " + schemeName + "(" + schemeData + ")");
-        }
-
-        try {
-            String line;
-            while ((line = rd.readLine()) != null) {
-                if (chars) {
-                    data += selectChars(line);
-                } else {
-                    data += selectLines(line);
+            // FIXME: Isn't there a better way to do this?
+            Matcher matcher = rangeRE.matcher(select);
+            if (matcher.matches()) {
+                String r = matcher.group(1);
+                if (r != null && !"".equals(r)) {
+                    sp = Integer.parseInt(r);
+                }
+                r = matcher.group(3);
+                if (r != null && !"".equals(r)) {
+                    ep = Integer.parseInt(r);
                 }
             }
-        } catch (IOException ioe) {
-            throw new XProcException(ioe);
-        }
 
-        try {
-            rd.close();
-        } catch (IOException ioe) {
-            throw new XProcException(ioe);
-        }
+            if (select.startsWith("char=")) {
+                chars = true;
+            } else if (select.startsWith("line=")) {
+                chars = false;
+            } else {
+                throw new XProcException("Unparseable XPointer: " + schemeName + "(" + schemeData + ")");
+            }
 
+            try {
+                String line;
+                while ((line = rd.readLine()) != null) {
+                    if (chars) {
+                        data += selectChars(line);
+                    } else {
+                        data += selectLines(line);
+                    }
+                }
+            } catch (IOException ioe) {
+                throw new XProcException(ioe);
+            }
+        } finally {
+            try {
+                rd.close();
+            } catch (IOException ioe) {
+                throw new XProcException(ioe);
+            }
+        }
         return data;
     }
 


### PR DESCRIPTION
This pull request closes many potential resource leaks by closing all resources in finally blocks.

It also includes a patch to build.xml to read the saxon version from the Version class instead of hardcoding it in the build file.

I recommend ignoring whitespace when viewing the differences in this pull request.  Github doesn't ignore whitespace when showing the differences, but you can do that from the command-line:

> git diff -b -w 986694d 13fa597

or my favorite

> git diff -b -w --color 986694d 13fa597

Additional notes:
src/com/xmlcalabash/io/ReadableData.java
- changed so that underlying stream only gets closed manually when necessary

src/com/xmlcalabash/util/Base64.java
- Patched Base64 to prevent NullPointerExceptions and to log any exceptions
  on close (instead of silently swallowing them).  The following are still viable upgrade paths for Base64 in the future:
  - Upgrade to the next version (2.3) of 
    Base64 (http://iharder.net/base64). It's not backwards compatible, as it
    throws exceptions instead of silently swallowing them, so it's not a 
    drop-in replacement.  This patch doesn't make upgrading to the next version any more difficult.
  - Upgrade to Java 8 and java.util.Base64. API not compatible, so some 
    porting would be necessary.
