### PR TITLE
Better URI-to-File conversion

### DIFF
--- a/src/com/xmlcalabash/extensions/RDFStore.java
+++ b/src/com/xmlcalabash/extensions/RDFStore.java
@@ -8,9 +8,12 @@ import com.xmlcalabash.core.XProcRuntime;
 import com.xmlcalabash.runtime.XAtomicStep;
 import com.xmlcalabash.util.Base64;
 import com.xmlcalabash.util.TreeWriter;
+import com.xmlcalabash.util.URIUtils;
+
 import net.sf.saxon.s9api.QName;
 import net.sf.saxon.s9api.SaxonApiException;
 import net.sf.saxon.s9api.XdmNode;
+
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RiotReader;
 import org.apache.jena.riot.lang.LangRIOT;
@@ -105,7 +108,7 @@ public class RDFStore extends RDFStep {
                 baos = new ByteArrayOutputStream();
                 outstr = baos;
             } else if (href.getScheme().equals("file")) {
-                File output = new File(href);
+                File output = URIUtils.toFile(href);
 
                 File path = new File(output.getParent());
                 if (!path.isDirectory()) {

--- a/src/com/xmlcalabash/extensions/fileutils/Info.java
+++ b/src/com/xmlcalabash/extensions/fileutils/Info.java
@@ -13,6 +13,8 @@ import com.xmlcalabash.util.AxisNodes;
 import com.xmlcalabash.util.MessageFormatter;
 import com.xmlcalabash.util.TreeWriter;
 import com.xmlcalabash.util.S9apiUtils;
+import com.xmlcalabash.util.URIUtils;
+
 import net.sf.saxon.s9api.QName;
 import net.sf.saxon.s9api.SaxonApiException;
 import net.sf.saxon.s9api.XdmNode;
@@ -90,7 +92,7 @@ public class Info extends DefaultStep {
         tree.startDocument(step.getNode().getBaseURI());
 
         if ("file".equals(uri.getScheme())) {
-            File file = new File(uri.getPath());
+            File file = URIUtils.toFile(uri);
 
             if (!file.exists()) {
                 if (failOnError) {

--- a/src/com/xmlcalabash/extensions/fileutils/Tempfile.java
+++ b/src/com/xmlcalabash/extensions/fileutils/Tempfile.java
@@ -8,6 +8,8 @@ import com.xmlcalabash.core.XProcException;
 import com.xmlcalabash.runtime.XAtomicStep;
 import com.xmlcalabash.model.RuntimeValue;
 import com.xmlcalabash.util.TreeWriter;
+import com.xmlcalabash.util.URIUtils;
+
 import net.sf.saxon.s9api.QName;
 import net.sf.saxon.s9api.SaxonApiException;
 
@@ -72,7 +74,7 @@ public class Tempfile extends DefaultStep {
         if (!"file".equals(uri.getScheme())) {
             throw new XProcException(step.getNode(), "Only file: scheme URIs are supported by the tempfile step.");
         } else {
-            file = new File(uri.getPath());
+            file = URIUtils.toFile(uri);
         }
 
         if (!file.isDirectory()) {

--- a/src/com/xmlcalabash/io/FileDataStore.java
+++ b/src/com/xmlcalabash/io/FileDataStore.java
@@ -21,6 +21,8 @@
 package com.xmlcalabash.io;
 
 import com.xmlcalabash.core.XProcException;
+import com.xmlcalabash.util.URIUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,7 +69,7 @@ public class FileDataStore implements DataStore {
 		URI baseURI = URI.create(base);
 		URI uri = baseURI.resolve(href);
 		if ("file".equalsIgnoreCase(uri.getScheme())) {
-			File file = new File(uri);
+			File file = URIUtils.toFile(uri);
 			String suffix = getFileSuffixFromType(media);
 			if (file.isDirectory() || uri.getPath().endsWith("/")) {
 				if (!file.isDirectory() && !file.mkdirs()) {
@@ -114,7 +116,7 @@ public class FileDataStore implements DataStore {
 		URI baseURI = URI.create(base);
 		URI uri = baseURI.resolve(href);
 		if ("file".equalsIgnoreCase(uri.getScheme())) {
-			File file = new File(uri);
+		        File file = URIUtils.toFile(uri);
 			String type = getContentTypeFromName(file.getName());
             if (overrideContentType != null) {
                 type = overrideContentType;
@@ -136,7 +138,7 @@ public class FileDataStore implements DataStore {
 		URI baseURI = URI.create(base);
 		URI uri = baseURI.resolve(href);
 		if ("file".equalsIgnoreCase(uri.getScheme())) {
-			File file = new File(uri);
+		        File file = URIUtils.toFile(uri);
 			String type;
 			if (file.isFile()) {
 				type = getContentTypeFromName(file.getName());
@@ -157,7 +159,7 @@ public class FileDataStore implements DataStore {
 		URI baseURI = URI.create(base);
 		URI uri = baseURI.resolve(href);
 		if ("file".equalsIgnoreCase(uri.getScheme())) {
-			File file = new File(uri);
+		        File file = URIUtils.toFile(uri);
 
             if (!file.canRead()) {
                 throw XProcException.stepError(12);
@@ -186,7 +188,7 @@ public class FileDataStore implements DataStore {
 		URI baseURI = URI.create(base);
 		URI uri = baseURI.resolve(href);
 		if ("file".equalsIgnoreCase(uri.getScheme())) {
-			File file = new File(uri);
+		        File file = URIUtils.toFile(uri);
 			if (file.isDirectory()) {
 				return file.toURI();
 			} else if (file.exists()) {
@@ -209,7 +211,7 @@ public class FileDataStore implements DataStore {
 		URI baseURI = URI.create(base);
 		URI uri = baseURI.resolve(href);
 		if ("file".equalsIgnoreCase(uri.getScheme())) {
-			File file = new File(uri);
+		        File file = URIUtils.toFile(uri);
 			if (!file.exists()) {
 				throw new FileNotFoundException(file.toURI().toASCIIString());
 			} else if (!file.delete()) {

--- a/src/com/xmlcalabash/util/URIUtils.java
+++ b/src/com/xmlcalabash/util/URIUtils.java
@@ -21,6 +21,7 @@
 package com.xmlcalabash.util;
 
 import com.xmlcalabash.core.XProcException;
+
 import java.io.UnsupportedEncodingException;
 import java.io.File;
 import java.net.URI;
@@ -99,5 +100,11 @@ public class URIUtils {
     public static URI makeAbsolute(String localFn) {
         URI cwd = cwdAsURI();
         return cwd.resolve(encode(localFn));
+    }
+    
+    public static File toFile(URI uri) {
+        if (!"file".equalsIgnoreCase(uri.getScheme()))
+            throw new IllegalStateException("Expecting a file URI");
+        return new File((uri.getAuthority() != null && uri.getAuthority().length() > 0)?"//"+uri.getAuthority()+uri.getPath():uri.getPath());
     }
 }


### PR DESCRIPTION
This should notably better handle UNC paths, which are often
represented as file URIs with an authority component.

I tested a few I/O-involving steps using [this test file](https://gist.github.com/rdeltour/0bb718ba4ed490be2b77).
There might be some URI-to-File conversion leftovers that are not properly handled (e.g. I haven't touched `XProcConfiguration`), but this PR should cover most of the step implementations.
