### PR TITLE
<p:serialization> method attribute parsed incorrectly if there is a default namespace

### DIFF
--- a/src/com/xmlcalabash/model/Parser.java
+++ b/src/com/xmlcalabash/model/Parser.java
@@ -1073,7 +1073,12 @@ public class Parser {
 
         value = node.getAttributeValue(new QName("method"));
         if (value != null) {
-            QName name = new QName(value, node);
+            QName name;
+            if (value.contains(":"))
+                name = new QName(value, node);
+            else
+                name = new QName(value);
+
             if ("".equals(name.getPrefix())) {
                 String method = name.getLocalName();
                 if ("html".equals(method) || "xhtml".equals(method) || "text".equals(method) || "xml".equals(method)) {


### PR DESCRIPTION
In my pipelines, I like to use the XProc namespace as the default namespace. For the most part, this works fine, except for one bug: the value of the `method` attribute on `p:serialization` elements is interpreted as being in that default namespace!

This change fixes that. If the method name does not have a prefix, then it is now interpreted as being in no namespace, [as per the spec](http://www.w3.org/TR/xproc/#syntax-summaries).
