### PR TITLE
add more information to profiling output (saxon96)

### DIFF
--- a/src/com/xmlcalabash/core/XProcRuntime.java
+++ b/src/com/xmlcalabash/core/XProcRuntime.java
@@ -963,6 +963,8 @@ public class XProcRuntime {
         String name = step.getType().getClarkName();
         profileWriter.addAttribute(profileType, name);
         profileWriter.addAttribute(profileName, step.getStep().getName());
+        profileWriter.addAttribute(new QName("", "xpl-href"), ""+step.getStep().xplFile());
+        profileWriter.addAttribute(new QName("", "xpl-line"), ""+step.getStep().xplLine());
         profileWriter.startContent();
     }
 

--- a/src/com/xmlcalabash/runtime/XPipelineCall.java
+++ b/src/com/xmlcalabash/runtime/XPipelineCall.java
@@ -90,7 +90,9 @@ public class XPipelineCall extends XAtomicStep {
             }
         }
 
+        runtime.start(this);
         newstep.run();
+        runtime.finish(this);
 
     }
 }


### PR DESCRIPTION
- added xpl-href and xpl-line to profile elements
- create profile element when invoking custom steps

Makes it easier to parse the profiling output from calabash.
For instance, I'm using this XSLT to compare the XProc document with the profiling XML and get a HTML report:
https://gist.github.com/josteinaj/2c43cc3ae43e30c1e791
