### PR TITLE
use system property 'file.encoding' (fallback: UTF-8) for files

### DIFF
--- a/src/main/java/com/xmlcalabash/library/HttpRequest.java
+++ b/src/main/java/com/xmlcalabash/library/HttpRequest.java
@@ -1110,8 +1110,7 @@ public class HttpRequest extends DefaultStep {
             store.readEntry(href, base, "application/xml, text/xml, */*", overrideContentType, new DataReader() {
                 public void load(URI id, String contentType, InputStream bodyStream, long len)
                         throws IOException {
-                    // FIXME: Is ISO-8859-1 the right default?
-                    String charset = HttpUtils.getCharset(contentType, "ISO-8859-1");
+                    String charset = HttpUtils.getCharset(contentType, System.getProperty("file.encoding","UTF-8"));
 
                     TreeWriter tree = new TreeWriter(runtime);
                     tree.startDocument(id);


### PR DESCRIPTION
I had to use p:http-request to read local non-XML files. (Is there another step for doing this?)
The files contained UTF-8 encoded snippets of XHTML5 files, no encoding declaration whatsoever in them. I added the validator.nu jar to be able to parse them as text/html. They were read as if they had an ISO-8859-1 charset. 
Since I specify -Dfile-encoding=UTF-8 in my front-end script for calabash anyway, I thought that calabash might want to make use of this system property, if set. If it isn’t set, I think it’s a sensible choice in 2015 to use UTF-8 as default.
