### PR TITLE
Fixes to the generation of the Maven pom.xml files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -419,6 +419,54 @@ gradle.taskGraph.whenReady { taskGraph ->
   }
 }
 
+def mavenPom = {
+  name 'XML Calabash'
+  packaging 'jar'
+  description 'An XProc 1.0 processor'
+  url 'https://github.com/ndw/xmlcalabash1'
+
+  scm {
+    url 'scm:git@github.com:ndw/xmlcalabash1.git'
+    connection 'scm:git@github.com:ndw/xmlcalabash1.git'
+    developerConnection 'scm:git@github.com:ndw/xmlcalabash1.git'
+  }
+
+  licenses {
+    license {
+      name 'Common Development and Distribution License (CDDL) version 1.0'
+      url 'http://www.opensource.org/licenses/cddl1.txt'
+      distribution 'repo'
+    }
+    license {
+      name 'GNU General Public License version 2'
+      url 'http://www.gnu.org/licenses/gpl-2.0.txt'
+      distribution 'repo'
+    }
+  }
+
+  developers {
+    developer {
+      id 'ndw'
+      name 'Norman Walsh'
+    }
+  }
+
+  repositories {
+    repository {
+      id 'restlet'
+      url 'http://maven.restlet.org'
+    }
+  }
+}
+
+install {
+  repositories {
+    mavenInstaller {
+      pom.project(mavenPom)
+    }
+  }
+}
+
 uploadArchives {
   repositories {
     mavenDeployer {
@@ -434,46 +482,7 @@ uploadArchives {
         authentication(userName: sonatypeUsername, password: sonatypePassword)
       }
 
-      pom.project {
-        name 'XML Calabash'
-        packaging 'jar'
-        description 'An XProc 1.0 processor'
-        url 'https://github.com/ndw/xmlcalabash1'
-
-        scm {
-          url 'scm:git@github.com:ndw/xmlcalabash1.git'
-          connection 'scm:git@github.com:ndw/xmlcalabash1.git'
-          developerConnection 'scm:git@github.com:ndw/xmlcalabash1.git'
-        }
-
-        licenses {
-          license {
-            name 'Common Development and Distribution License (CDDL) version 1.0'
-            url 'http://www.opensource.org/licenses/cddl1.txt'
-            distribution 'repo'
-          }
-          license {
-            name 'GNU General Public License version 2'
-            url 'http://www.gnu.org/licenses/gpl-2.0.txt'
-            distribution 'repo'
-          }
-        }
-
-        developers {
-          developer {
-            id 'ndw'
-            name 'Norman Walsh'
-          }
-        }
-
-        repositories {
-          repository {
-            id 'restlet'
-            url 'http://maven.restlet.org'
-          }
-        }
-      }
-
+      pom.project(mavenPom)
     }
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -465,7 +465,15 @@ uploadArchives {
             name 'Norman Walsh'
           }
         }
+
+        repositories {
+          repository {
+            id 'restlet'
+            url 'http://maven.restlet.org'
+          }
+        }
       }
+
     }
   }
 }


### PR DESCRIPTION
The published Maven pom.xml file for version `1.1.9-96` is missing a required repository to be able to use the artifact with a Maven project.

i.e. https://repo1.maven.org/maven2/com/xmlcalabash/xmlcalabash/1.1.9-96/xmlcalabash-1.1.9-96.pom is missing the section:

``` xml
<repositories>
    <repository>
        <id>restlet</id>
        <url>http://maven.restlet.org</url>
    </repository>
</repositories>
```

which is required to resolve it's dependency on: `org.restlet.jee:*:2.2.2`.

This PR ensures that:
1. The repository is added to the pom.xml before publishing.
2. The `install` task also generates the correct pom.xml.
