### PR TITLE
Fix broken serialization of binary http uploads

### DIFF
--- a/src/main/java/com/xmlcalabash/library/HttpRequest.java
+++ b/src/main/java/com/xmlcalabash/library/HttpRequest.java
@@ -47,6 +47,7 @@ import net.sf.saxon.s9api.XdmSequenceIterator;
 import org.apache.http.Consts;
 import org.apache.http.Header;
 import org.apache.http.HeaderElement;
+import org.apache.http.HttpEntity;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
@@ -70,6 +71,7 @@ import org.apache.http.client.protocol.ClientContext;
 import org.apache.http.cookie.Cookie;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.ContentType;
+import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.impl.client.BasicCredentialsProvider;
@@ -561,14 +563,13 @@ public class HttpRequest extends DefaultStep {
         if (encoding != null && !"base64".equals(encoding)) {
             throw XProcException.stepError(52);
         }
+        
+        HttpEntity requestEntity = null;
 
         try {
             if ("base64".equals(encoding)) {
-                String charset = body.getAttributeValue(_charset);
-                // FIXME: is utf-8 the right default?
-                if (charset == null) { charset = "utf-8"; }
-
-                // Make sure it's all characters
+                // Content is binary, and must be serialized as an array of bytes
+                // Make sure it's all characters (no markup)
                 XdmSequenceIterator iter = body.axisIterator(Axis.CHILD);
                 while (iter.hasNext()) {
                     XdmNode node = (XdmNode) iter.next();
@@ -576,13 +577,11 @@ public class HttpRequest extends DefaultStep {
                         throw XProcException.stepError(28);
                     }
                 }
-
-                String escapedContent = decodeBase64(body, charset);
-                StringWriter writer = new StringWriter();
-                writer.write(escapedContent);
-                writer.close();
-                postContent = writer.toString();
+                String content = extractText(body);
+                byte[] decoded = Base64.decode(content);
+                requestEntity = new ByteArrayEntity(decoded, ContentType.create(contentType));
             } else {
+                // content is textual; either JSON, XML, or plain text, and can be serialized as a String
                 if (jsonContentType(contentType)) {
                     postContent = XMLtoJSON.convert(body);
                 } else if (xmlContentType(contentType)) {
@@ -620,9 +619,9 @@ public class HttpRequest extends DefaultStep {
                     writer.close();
                     postContent = writer.toString();
                 }
+                requestEntity = new StringEntity(postContent, ContentType.create(contentType, "UTF-8"));
             }
 
-            StringEntity requestEntity = new StringEntity(postContent, ContentType.create(contentType, "UTF-8"));
             method.setEntity(requestEntity);
 
         } catch (IOException ioe) {

--- a/src/main/java/com/xmlcalabash/library/HttpRequest.java
+++ b/src/main/java/com/xmlcalabash/library/HttpRequest.java
@@ -1093,16 +1093,6 @@ public class HttpRequest extends DefaultStep {
         return content;
     }
 
-    private String decodeBase64(XdmNode doc, String charset) {
-        String content = extractText(doc);
-        byte[] decoded = Base64.decode(content);
-        try {
-            return new String(decoded, charset);
-        } catch (UnsupportedEncodingException uee) {
-            throw XProcException.stepError(10, uee);
-        }
-    }
-
     private void doFile(String href, String base) {
         try {
             DataStore store = runtime.getDataStore();


### PR DESCRIPTION
This commit fixes a bug which can corrupt the entity body of binary http uploads.

Previously, binary content was treated as text with a particular character encoding, but in fact a base64-encoded `c:body` does not have a 'character encoding' since it represents a sequence of bytes, not characters.

I discovered this while trying to upload a PDF file, which was read from a file: URI successfully using `p:http-request`, and could be saved with `p:store` to produce an identical file, but which was corrupted when PUT to an http: URI using `p:http-request`.

I tested this using curl, a web service that accepts PUT, and a logging TCP tunnel; by comparing the HTTP request made by curl with the request made by my pipeline I was able to identify the underlying problem in the `http-request` step's implementation. However, I struggled to build a test case for this using Calabash's test framework.
