### PR TITLE
StepAvailable: if 'step' is null, return false

### DIFF
--- a/src/main/java/com/xmlcalabash/functions/StepAvailable.java
+++ b/src/main/java/com/xmlcalabash/functions/StepAvailable.java
@@ -95,6 +95,9 @@ public class StepAvailable extends XProcExtensionFunctionDefinition {
 
             XProcRuntime runtime = registry.getRuntime(xdef);
             XStep step = runtime.getXProcData().getStep();
+            if (step == null) {
+                return BooleanValue.FALSE;
+            }
             // FIXME: this can't be the best way to do this...
             // step == null in use-when
             if (step != null && !(step instanceof XCompoundStep)) {


### PR DESCRIPTION
I'm getting a NullPointerException in StepAvailable.java:

```
java.lang.NullPointerException
	at com.xmlcalabash.functions.StepAvailable$StepAvailableCall.call(StepAvailable.java:121) ~[xmlcalabash-1.1.15-96.jar:1.1.15-96]
	at net.sf.saxon.lib.ExtensionFunctionCall.effectiveBooleanValue(ExtensionFunctionCall.java:208) ~[Saxon-HE-9.6.0-4.jar:?]
	at net.sf.saxon.functions.IntegratedFunctionCall.effectiveBooleanValue(IntegratedFunctionCall.java:318) ~[Saxon-HE-9.6.0-4.jar:?]
	at net.sf.saxon.functions.BooleanFn.effectiveBooleanValue(BooleanFn.java:159) ~[Saxon-HE-9.6.0-4.jar:?]
	at net.sf.saxon.functions.BooleanFn.evaluateItem(BooleanFn.java:150) ~[Saxon-HE-9.6.0-4.jar:?]
	at net.sf.saxon.functions.BooleanFn.evaluateItem(BooleanFn.java:28) ~[Saxon-HE-9.6.0-4.jar:?]
	at net.sf.saxon.expr.Expression.iterate(Expression.java:448) ~[Saxon-HE-9.6.0-4.jar:?]
	at net.sf.saxon.sxpath.XPathExpression.iterate(XPathExpression.java:175) ~[Saxon-HE-9.6.0-4.jar:?]
	at net.sf.saxon.s9api.XPathSelector.iterator(XPathSelector.java:200) ~[Saxon-HE-9.6.0-4.jar:?]
	at com.xmlcalabash.runtime.XAtomicStep.evaluateXPath(XAtomicStep.java:856) ~[xmlcalabash-1.1.15-96.jar:1.1.15-96]
	at com.xmlcalabash.runtime.XWhen.shouldRun(XWhen.java:43) ~[xmlcalabash-1.1.15-96.jar:1.1.15-96]
	at com.xmlcalabash.runtime.XChoose.run(XChoose.java:107) ~[xmlcalabash-1.1.15-96.jar:1.1.15-96]
	at com.xmlcalabash.runtime.XPipeline.doRun(XPipeline.java:236) ~[xmlcalabash-1.1.15-96.jar:1.1.15-96]
	at com.xmlcalabash.runtime.XPipeline.run(XPipeline.java:136) ~[xmlcalabash-1.1.15-96.jar:1.1.15-96]
	at com.xmlcalabash.runtime.XPipelineCall.run(XPipelineCall.java:94) ~[xmlcalabash-1.1.15-96.jar:1.1.15-96]
	at com.xmlcalabash.runtime.XPipeline.doRun(XPipeline.java:236) ~[xmlcalabash-1.1.15-96.jar:1.1.15-96]
	at com.xmlcalabash.runtime.XPipeline.run(XPipeline.java:136) ~[xmlcalabash-1.1.15-96.jar:1.1.15-96]
	at com.xmlcalabash.drivers.Main.run(Main.java:365) ~[xmlcalabash-1.1.15-96.jar:1.1.15-96]
	at com.xmlcalabash.drivers.Main.run(Main.java:112) [xmlcalabash-1.1.15-96.jar:1.1.15-96]
	at com.xmlcalabash.drivers.Main.main(Main.java:83) [xmlcalabash-1.1.15-96.jar:1.1.15-96]
```

I haven't been able to reproduce it as a test in the test suite. However, checking for null and returning false in case of null seems to work in my case. If you want to reproduce, follow the "getting started" part for [xprocspec](http://daisy.github.io/xprocspec/) with Calabash 1.0.32 or newer.