### PR TITLE
Fix memory leak in cx:eval

### DIFF
--- a/src/main/java/com/xmlcalabash/core/XProcRuntime.java
+++ b/src/main/java/com/xmlcalabash/core/XProcRuntime.java
@@ -310,6 +310,12 @@ public class XProcRuntime {
 
         initializeSteps();
     }
+    
+    public void resetExtensionFunctions() {
+        for (XProcExtensionFunctionDefinition xf : exFuncs) {
+            processor.registerExtensionFunction(xf);
+        }
+    }
 
     private void initializeSteps() {
         for (Class<?> klass : config.implementations.values()) {

--- a/src/main/java/com/xmlcalabash/extensions/Eval.java
+++ b/src/main/java/com/xmlcalabash/extensions/Eval.java
@@ -110,6 +110,8 @@ public class Eval extends DefaultStep {
 
         XProcRuntime innerRuntime = new XProcRuntime(runtime);
 
+        try {
+
         QName stepName = getOption(_step, (QName) null);
         XPipeline pipeline = null;
         if (XProcConstants.p_pipeline.equals(piperoot.getNodeName())
@@ -271,6 +273,11 @@ public class Eval extends DefaultStep {
                 tree.endDocument();
                 result.write(tree.getResult());
             }
+        }
+
+        } finally {
+            innerRuntime.close();
+            runtime.resetExtensionFunctions();
         }
     }
 }


### PR DESCRIPTION
Currently the XProcRuntime instances in XProcRegistry aren't always cleaned up properly when cx:eval is used. It's the same issue that I reported a while ago in https://github.com/ndw/xmlcalabash1/issues/82#issuecomment-15068649.

This PR is the quick fix, however it seems to me that the real problem lies within XProcRegistry. I guess I just don't see what this class does. From what I can tell, you could just as well store the XProcRuntime directly inside the XProcExtensionFunctionDefinition. I think I have to agree with what @jwcranford said in https://github.com/ndw/xmlcalabash1/issues/152#issuecomment-46644568. [This patch from @rdeltour from back in 2011](https://github.com/rdeltour/xmlcalabash1/commit/fca649faab50180186ba3b8aeceffa48954f8ae4) still seems relevant indeed.

For reference: these are all the previous issues and commits I could find about this topic, in chronological order:

- https://code.google.com/archive/p/xmlcalabash/issues/153
- https://github.com/ndw/xmlcalabash1/commit/db9ad9b1eacf52eb00e6b7cfae22c2f77c6ce6c7
- https://github.com/ndw/xmlcalabash1/commit/f14974b56f15e791c7f61411c5884ac415cdbe8f
- https://github.com/ndw/xmlcalabash1/pull/69
- https://github.com/ndw/xmlcalabash1/commit/8918f8c6c84747a1ae73cda08627b7bc231a90d5
- https://github.com/ndw/xmlcalabash1/issues/82
- https://github.com/ndw/xmlcalabash1/commit/9852719bbe7aea23ce0cc14e8d6ba0190ddda2af
- https://github.com/ndw/xmlcalabash1/issues/152
- https://github.com/ndw/xmlcalabash1/commit/e6e1c50a4ea0f2e5023b3e78b062cd2b9df2605e
- https://github.com/ndw/xmlcalabash1/issues/183
- https://github.com/ndw/xmlcalabash1/commit/35dc7f399e138dba078e04b3729796e322812677
