### PR TITLE
Initialize  runtime if not initialized when called from Ant task

### DIFF
--- a/src/main/java/com/xmlcalabash/drivers/Main.java
+++ b/src/main/java/com/xmlcalabash/drivers/Main.java
@@ -178,6 +178,10 @@ public class Main {
 
         XPipeline pipeline = null;
 
+        if (runtime == null) {
+        	runtime = new XProcRuntime(config);
+        }
+        
         if (userArgs.getPipeline() != null) {
             pipeline = runtime.load(userArgs.getPipeline());
         } else if (userArgs.hasImplicitPipeline()) {


### PR DESCRIPTION
Hello Mr Walsh.
This is a workaround for the issue #240. 

Regards, 

Laurent BIZE
