### PR TITLE
Use UUID for p:episode, rather than ms-resolution timestamp, …

### DIFF
--- a/src/main/java/com/xmlcalabash/core/XProcRuntime.java
+++ b/src/main/java/com/xmlcalabash/core/XProcRuntime.java
@@ -108,6 +108,7 @@ import java.util.Hashtable;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Stack;
+import java.util.UUID;
 import java.util.Vector;
 
 import static java.lang.String.format;
@@ -526,21 +527,8 @@ public class XProcRuntime {
 
     public String getEpisode() {
         if (episode == null) {
-            MessageDigest digest = null;
-            GregorianCalendar calendar = new GregorianCalendar();
-            try {
-                digest = MessageDigest.getInstance("MD5");
-            } catch (NoSuchAlgorithmException nsae) {
-                throw XProcException.dynamicError(36);
-            }
-
-            byte[] hash = digest.digest(calendar.toString().getBytes());
-            episode = "CB";
-            for (byte b : hash) {
-                episode = episode + Integer.toHexString(b & 0xff);
-            }
+            episode = "uuid_" + UUID.randomUUID().toString();
         }
-
         return episode;
     }
 


### PR DESCRIPTION
…to guarantee unique identifiers in a multi-threaded environment.

I've been running XMLCalabash embedded in a web-server environment to implement a "web API". During load testing with multiple simultaneous requests to the API pipeline I managed to invoke it several times per millisecond, and I found that the `p:episode` function was returning the same value in such cases, though the spec says the values _should_ be different:

> Returns a string which should be unique for each invocation of the pipeline processor. In other words, if a processor is run several times in succession, or if several processors are running simultaneously, each invocation of each processor should get a distinct value from `p:episode`.

I had been using the value of `p:episode` as a unique id for logging each individual call to the API pipeline, and the identifier collisions broke that; that's how I discovered the problem.