### PR TITLE
add support for other HTTP methods

### DIFF
--- a/src/test/java/com/xmlcalabash/testsuite/TestRequired.java
+++ b/src/test/java/com/xmlcalabash/testsuite/TestRequired.java
@@ -2344,6 +2344,16 @@ public class TestRequired {
     }
 
     @Test
+    public void testOptionsHttpRequest() {
+        suiteRunner.runTest(TESTROOT + "options-http-request.xml");
+    }
+    
+    @Test
+    public void testOptionsHttpRequestWithBody() {
+        suiteRunner.runTest(TESTROOT + "options-http-request-with-body.xml");
+    }
+    
+    @Test
     public void testOutput001() {
         suiteRunner.runTest(TESTROOT + "output-001.xml");
     }

--- a/test/testsuite/required/options-http-request-with-body.xml
+++ b/test/testsuite/required/options-http-request-with-body.xml
@@ -2,7 +2,7 @@
 <?xml-stylesheet type="text/xsl" href="http://tests.xproc.org/style/testcase.xsl"?>
 <t:test xmlns:t="http://xproc.org/ns/testsuite">
 
-	<t:title>Test options-http-request</t:title>
+	<t:title>Test options-http-request-with-body</t:title>
 
 	<t:pipeline>
 		<p:declare-step version="1.0" name="main" xmlns:p="http://www.w3.org/ns/xproc" xmlns:c="http://www.w3.org/ns/xproc-step" xmlns:test="tag:conaltuohy.com,2019:xmlcalabash-test" xmlns:err="http://www.w3.org/ns/xproc-error">

--- a/test/testsuite/required/options-http-request-with-body.xml
+++ b/test/testsuite/required/options-http-request-with-body.xml
@@ -1,0 +1,32 @@
+
+<?xml-stylesheet type="text/xsl" href="http://tests.xproc.org/style/testcase.xsl"?>
+<t:test xmlns:t="http://xproc.org/ns/testsuite">
+
+	<t:title>Test options-http-request</t:title>
+
+	<t:pipeline>
+		<p:declare-step version="1.0" name="main" xmlns:p="http://www.w3.org/ns/xproc" xmlns:c="http://www.w3.org/ns/xproc-step" xmlns:test="tag:conaltuohy.com,2019:xmlcalabash-test" xmlns:err="http://www.w3.org/ns/xproc-error">
+			<p:output port="result"/>
+
+			<p:declare-step type="test:options-http-request">
+				<p:output port="result"/>
+				<p:http-request name="http">
+					<p:input port="source">
+						<p:inline>
+							<c:request method="options" detailed="true" status-only="true" href="http://tests.xproc.org/service/fixed-text">
+								<c:body content-type="text/plain">a sample message body</c:body>
+							</c:request>
+						</p:inline>
+					</p:input>
+				</p:http-request>
+				<p:delete match="/c:response/c:header"/>
+			</p:declare-step>
+			<test:options-http-request/>
+		</p:declare-step>
+	</t:pipeline>
+
+	<t:output port="result" xmlns:c="http://www.w3.org/ns/xproc-step">
+		<c:response status="200"/>
+	</t:output>
+
+</t:test>

--- a/test/testsuite/required/options-http-request.xml
+++ b/test/testsuite/required/options-http-request.xml
@@ -1,0 +1,30 @@
+
+<?xml-stylesheet type="text/xsl" href="http://tests.xproc.org/style/testcase.xsl"?>
+<t:test xmlns:t="http://xproc.org/ns/testsuite">
+
+	<t:title>Test options-http-request</t:title>
+
+	<t:pipeline>
+		<p:declare-step version="1.0" name="main" xmlns:p="http://www.w3.org/ns/xproc" xmlns:c="http://www.w3.org/ns/xproc-step" xmlns:test="tag:conaltuohy.com,2019:xmlcalabash-test" xmlns:err="http://www.w3.org/ns/xproc-error">
+			<p:output port="result"/>
+
+			<p:declare-step type="test:options-http-request">
+				<p:output port="result"/>
+				<p:http-request name="http">
+					<p:input port="source">
+						<p:inline>
+							<c:request method="options" detailed="true" status-only="true" href="http://tests.xproc.org/service/fixed-text"/>
+						</p:inline>
+					</p:input>
+				</p:http-request>
+				<p:delete match="/c:response/c:header"/>
+			</p:declare-step>
+			<test:options-http-request/>
+		</p:declare-step>
+	</t:pipeline>
+
+	<t:output port="result" xmlns:c="http://www.w3.org/ns/xproc-step">
+		<c:response status="200"/>
+	</t:output>
+
+</t:test>

--- a/test/testsuite/required/test-suite.xml
+++ b/test/testsuite/required/test-suite.xml
@@ -1,5 +1,6 @@
 <t:test-suite xmlns:t='http://xproc.org/ns/testsuite'>
 <t:title>Required tests</t:title>
+<t:test href='options-http-request.xml'/>
 <t:test href='add-attribute-001.xml'/>
 <t:test href='add-attribute-002.xml'/>
 <t:test href='add-attribute-003.xml'/>


### PR DESCRIPTION
Prompted by the recent updates to the XProc 3.0 issue about HTTP methods, [where I argued that an XProc processor should support any method](https://github.com/xproc/3.0-steps/issues/42#issuecomment-501582461), I finally got around to the refactoring we discussed [a while back](https://github.com/ndw/xmlcalabash1/pull/269#issuecomment-370268025), when I had quickly patched in HTTP `PATCH`.

I've added two inner classes to implement HTTP requests with a body, and without a body, which are used when the `c:request/@method` is not one of the specifically-handled methods like `GET` and `PUT`. If you supply a body, you get one of those classes; if you don't supply a body, you get the other.

I "flipped" the sanity check which used to ensure that you didn't supply a body along with a method which doesn't call for a body, so that it uses an "open world" assumption, and rejects only the cases which it knows are definitely in error, and otherwise (if the method is not known) it assumes that you know what you're doing.

The additional tests make HTTP `OPTIONS` requests, both with and without a body, and check that the server responds with `200` OK to both.