### PR TITLE
Fix bug in default readable output port

### DIFF
--- a/src/main/java/com/xmlcalabash/model/Step.java
+++ b/src/main/java/com/xmlcalabash/model/Step.java
@@ -371,23 +371,35 @@ public class Step extends SourceArtifact {
     
     public Output getDefaultOutput() {
         // See if there's exactly one "ordinary" output
-        int count = 0;
         Output defout = null;
         for (Output output : outputs) {
             if (!output.getPort().startsWith("#")) {
                 if (output.getPrimary()) {
-                    return output;
-                }
-                if (!output.getPort().endsWith("|")) {
-                    count++;
-                    defout = output;
+                    if (!output.getPort().endsWith("|"))
+                        return output;
+                    else
+                        defout = output;
                 }
             }
         }
         
-        if (count == 1 && (defout.getPrimary() || !defout.getPrimarySet())) {
-            return defout;
+        if (defout != null) return defout;
+        
+        int count = 0;
+        for (Output output : outputs) {
+            if (!output.getPort().startsWith("#")) {
+                if (!output.getPort().endsWith("|")) {
+                    if (++count > 1)
+                        return null;
+                    else
+                        defout = output;
+                }
+            }
         }
+        
+        if (defout != null)
+            if (!defout.getPrimarySet())
+                return defout;
         
         return null;
     }


### PR DESCRIPTION
I'm sorry that I don't have a better description of the problem. I spent some time trying to reproduce the issue with a simple test case but I didn't manage to. All I can say is that in some of my pipelines the issue occurred that no automatic connection was made where you would  expect one to be made, and there was no reason whatsoever why it should behave like it did. To me it was quite clear that is was a bug.

My patch fixes the problem. Unfortunately I can't explain what I did because it's hard to understand what is going on in that code. On the bright side, I have been using it for a while though and there don't seem to be any negative side effects for me, which makes me confident that it didn't screw up.

I'm hoping that you do understand the code and can confirm that I indeed fixed a bug, and that you are willing to accept the patch as is.