### PR TITLE
Fixes endless loop in Zip.readStream()

### DIFF
--- a/src/main/java/com/xmlcalabash/extensions/Zip.java
+++ b/src/main/java/com/xmlcalabash/extensions/Zip.java
@@ -261,6 +261,7 @@ public class Zip extends DefaultStep {
             ZipEntry entry = zipStream.getNextEntry();
             while (entry != null) {
                 processEntry(tree, entry, dfactory);
+                entry = zipStream.getNextEntry();
             }
         } finally {
             zipStream.close();


### PR DESCRIPTION
Hi,

as far as I can see it always ends in an endless loop if `pxp:zip` is used with another protocol than `file:` in href.

This should fix it...